### PR TITLE
Updated README For Use With Kafka Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See [Confluent's documentation](https://docs.confluent.io/current/connect/securi
 
 The following examples assume you're deploying to an [existing Kafka Connect cluster](#connector-in-an-existing-kafka-connect-cluster) or a [dedicated Kafka Connect cluster](#connector-in-a-dedicated-kafka-connect-cluster).
 
-If you are using [Quick Start](https://github.com/splunk/kafka-connect-splunk#quick-start), adjust the config file to **config/connect-distributed-quickstart.properties**.
+If you are using [Quick Start](#quick-start), adjust the config file to **config/connect-distributed-quickstart.properties**.
 
 ### SSL
 This section documents how to configure Kafka Connect if your Kafka Cluster is secured using [SSL](http://kafka.apache.org/documentation/#security_ssl).


### PR DESCRIPTION
I've updated the README to document configuring Kafka Connect workers and consumers for the available security mechanisms in Kafka.

SSL
SASL/GSSAPI (Kerberos) - starting at version 0.9.0.0
SASL/PLAIN - starting at version 0.10.0.0
SASL/SCRAM-SHA-256 and SASL/SCRAM-SHA-512 - starting at version 0.10.2.0

Please review and merge if everything looks good.