### PR TITLE
recalculate the batch length when more metadata was injected

### DIFF
--- a/src/main/java/com/splunk/hecclient/Event.java
+++ b/src/main/java/com/splunk/hecclient/Event.java
@@ -93,7 +93,6 @@ public abstract class Event {
         return this;
     }
 
-
     public final Long getTime() {
         return time;
     }

--- a/src/main/java/com/splunk/hecclient/EventBatch.java
+++ b/src/main/java/com/splunk/hecclient/EventBatch.java
@@ -36,9 +36,13 @@ public abstract class EventBatch {
     public abstract EventBatch createFromThis();
 
     public final void addExtraFields(final Map<String, String> fields) {
+        // recalculate the batch length since we inject more meta data to each event
+        int newLength = 0;
         for (final Event event: events) {
             event.addFields(fields);
+            newLength += event.length();
         }
+        len = newLength;
     }
 
     public final boolean isTimedout(long ttl) {


### PR DESCRIPTION
recalculate the batch length when more metadata was injected to each event