### PR TITLE
Fix for incorrect backoff calc, added more logging

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -211,3 +211,4 @@
     <junit.version>4.12</junit.version>
   </properties>
 </project>
+

--- a/src/main/java/com/splunk/hecclient/Indexer.java
+++ b/src/main/java/com/splunk/hecclient/Indexer.java
@@ -66,7 +66,7 @@ final class Indexer implements IndexerInf {
     }
 
     public Indexer setBackPressureThreshold(long threshold)  { //seconds
-        backPressureThreshold = threshold * 1000;
+        backPressureThreshold = threshold;
         return this;
     }
 
@@ -204,10 +204,12 @@ final class Indexer implements IndexerInf {
     @Override
     public boolean hasBackPressure() {
         if (backPressure > 0) {
-            if (System.currentTimeMillis() - lastBackPressure < backPressureThreshold) {
+            if ((System.currentTimeMillis() - lastBackPressure) < backPressureThreshold) {
+                log.warn("Still in Backpressure window {}:{}", System.currentTimeMillis() - lastBackPressure, backPressureThreshold);
                 // still in the back-pressure window
                 return true;
             } else {
+                log.info("Clearing Backpressure");
                 clearBackPressure();
                 return false;
             }

--- a/src/test/java/com/splunk/hecclient/IndexerTest.java
+++ b/src/test/java/com/splunk/hecclient/IndexerTest.java
@@ -106,7 +106,7 @@ public class IndexerTest {
 
         Indexer indexer = assertFailure(client);
         Assert.assertTrue(indexer.hasBackPressure());
-        indexer.setBackPressureThreshold(2);
+        indexer.setBackPressureThreshold(2000);
         UnitUtil.milliSleep(2500);
         Assert.assertFalse(indexer.hasBackPressure());
         // Assert again
@@ -120,10 +120,10 @@ public class IndexerTest {
 
         Indexer indexer = assertFailure(client);
         Assert.assertTrue(indexer.hasBackPressure());
-        indexer.setBackPressureThreshold(10);
+        indexer.setBackPressureThreshold(10000);
         UnitUtil.milliSleep(5000);
         Assert.assertTrue(indexer.hasBackPressure());
-        UnitUtil.milliSleep(5000);
+        UnitUtil.milliSleep(6000);
         Assert.assertFalse(indexer.hasBackPressure());
     }
 


### PR DESCRIPTION
Found double conversion from seconds to milliseconds causing incorrect backoff calculation