### PR TITLE
Fixed #196: tied sink record to json event

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -369,6 +369,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(connectorConfig.hecEventFormatted) {
             try {
                 event = objectMapper.readValue(record.value().toString(), JsonEvent.class);
+                event.setTied(record);
                 event.addFields(connectorConfig.enrichments);
             } catch(Exception e) {
                 log.error("event does not follow correct HEC pre-formatted format: {}", record.value().toString());


### PR DESCRIPTION
Fix so that offsets will get committed when using event-format instead of raw.