### PR TITLE
GH-221: Validate Splunk https URI configuration

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -224,6 +224,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         trustStorePath = getString(SSL_TRUSTSTORE_PATH_CONF);
         hasTrustStorePath = StringUtils.isNotBlank(trustStorePath);
         trustStorePassword = getPassword(SSL_TRUSTSTORE_PASSWORD_CONF).value();
+        validateHttpsConfig(splunkURI);
         eventBatchTimeout = getInt(EVENT_TIMEOUT_CONF);
         ackPollInterval = getInt(ACK_POLL_INTERVAL_CONF);
         ackPollThreads = getInt(ACK_POLL_THREADS_CONF);
@@ -417,5 +418,17 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
             idx += 1;
         }
         return metaMap;
+    }
+
+    private void validateHttpsConfig(String uriConf) {
+        List<String> uris = Arrays.asList(uriConf.split(","));
+        for (String uri: uris) {
+            if (uri.startsWith("https://") && this.validateCertificates && !this.hasTrustStorePath) {
+                throw new ConfigException("Invalid Secure HTTP (HTTPS) configuration: "
+                        + SplunkSinkConnectorConfig.URI_CONF + "='" + uriConf + "',"
+                        + SplunkSinkConnectorConfig.SSL_VALIDATE_CERTIFICATES_CONF + "='" + this.validateCertificates + "',"
+                        + SplunkSinkConnectorConfig.SSL_TRUSTSTORE_PATH_CONF + "='" + this.trustStorePath + "'");
+            }
+        }
     }
 }

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -138,6 +138,15 @@ public class SplunkSinkConnectorConfigTest {
         SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
     }
 
+    @Test(expected = ConfigException.class)
+    public void createWithInvalidHttpsConfig() {
+        UnitUtil uu = new UnitUtil(0);
+        uu.configProfile.setValidateCertificates(true);
+        uu.configProfile.setTrustStorePath("");
+        Map<String, String> config = uu.createTaskConfig();
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
+    }
+
     @Test
     public void createWithMetaDataUniform() {
         // index, source, sourcetype have same number of elements


### PR DESCRIPTION
This fixes issue #221 wherein https URIs specified in the configuration could result in a runtime error due to the default values of `splunk.hec.ssl.validate.certs` is true and `splunk.hec.ssl.trust.store.path` is empty.

We validate the configuration to avoid the runtime errors.