### PR TITLE
add support for topics.regex for splunk sink connector

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.splunk.kafka.connect</groupId>
   <artifactId>splunk-kafka-connect</artifactId>
   <name>splunk-kafka-connect</name>
-  <version>v2.0.2</version>
+  <version>v2.0.3</version>
   <build>
     <plugins>
       <plugin>
@@ -201,14 +201,14 @@
     </plugins>
   </reporting>
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <junit.platform.version>1.0.1</junit.platform.version>
     <java.version>1.8</java.version>
+    <junit.vintage.version>${junit.version}.1</junit.vintage.version>
+    <junit.jupiter.version>5.0.1</junit.jupiter.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <junit.version>4.12</junit.version>
-    <junit.jupiter.version>5.0.1</junit.jupiter.version>
-    <junit.vintage.version>${junit.version}.1</junit.vintage.version>
-    <junit.platform.version>1.0.1</junit.platform.version>
   </properties>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>splunk-kafka-connect</artifactId>
-    <version>v2.0.2</version>
+    <version>v2.0.3</version>
     <name>splunk-kafka-connect</name>
 
     <properties>

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -206,7 +206,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         Header sourceHeader = headers.lastWithName(connectorConfig.headerSource);
         Header sourcetypeHeader = headers.lastWithName(connectorConfig.headerSourcetype);
 
-        Map<String, String> metas = connectorConfig.topicMetas.get(sinkRecord.topic());
+        Map<String, String> metas = connectorConfig.getTopicMetadata(sinkRecord.topic());
 
 
         StringBuilder headerString = new StringBuilder();
@@ -313,7 +313,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
             return RawEventBatch.factory().build();
         }
 
-        Map<String, String> metas = connectorConfig.topicMetas.get(tp.topic());
+        Map<String, String> metas = connectorConfig.getTopicMetadata(tp.topic());
         if (metas == null || metas.isEmpty()) {
             return RawEventBatch.factory().build();
         }
@@ -463,7 +463,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
             event.setTime(record.timestamp() / 1000.0); // record timestamp is in milliseconds
         }
 
-        Map<String, String> metas = connectorConfig.topicMetas.get(record.topic());
+        Map<String, String> metas = connectorConfig.getTopicMetadata(record.topic());
         if (metas != null) {
             event.setIndex(metas.get(SplunkSinkConnectorConfig.INDEX));
             event.setSourcetype(metas.get(SplunkSinkConnectorConfig.SOURCETYPE));

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
 gitbranch=release/2.0.x
-gitversion=v2.0.1
+gitversion=v2.0.3


### PR DESCRIPTION
fixes missing support for topics.regex functionality in kafka-connect (https://github.com/splunk/kafka-connect-splunk/issues/198)