### PR TITLE
splunk kafka connect update jackson databind from 2.10.3 to 20.10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.5</version>
             <scope>compile</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.5.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
splunk kafka connect update jackson databind from 2.10.3 to 20.10.5.1 to address CVE-2020-25649

A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.

Signed-off-by: esara <endre.sara@turbonomic.com>