### PR TITLE
Update SplunkSinkConnectorConfig.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use the below schema to configure Splunk Connect for Kafka
 "config": {
    "connector.class": "com.splunk.kafka.connect.SplunkSinkConnector",
    "tasks.max": "<number-of-tasks>",
-   "topics": "<list-of-topics-separated-by-comma>",
+   "topics" or "topics.regex": "<list-of-topics-separated-by-comma>" or "<regex to subscribe all the topics which match the regex pattern>"
    "splunk.indexes": "<list-of-indexes-for-topics-data-separated-by-comma>",
    "splunk.sources": "<list-of-sources-for-topics-data-separated-by-comma>",
    "splunk.sourcetypes": "<list-of-sourcetypes-for-topics-data-separated-by-comma>",
@@ -133,7 +133,7 @@ Use the below schema to configure Splunk Connect for Kafka
 | `tasks.max` |  The number of tasks generated to handle data collection jobs in parallel. The tasks will be spread evenly across all Splunk Kafka Connector nodes.||
 | `splunk.hec.uri` | Splunk HEC URIs. Either a list of FQDNs or IPs of all Splunk indexers, separated with a ",", or a load balancer. The connector will load balance to indexers using round robin. Splunk Connector will round robin to this list of indexers. `https://hec1.splunk.com:8088,https://hec2.splunk.com:8088,https://hec3.splunk.com:8088`||
 | `splunk.hec.token` |  [Splunk Http Event Collector token](http://docs.splunk.com/Documentation/SplunkCloud/6.6.3/Data/UsetheHTTPEventCollector#About_Event_Collector_tokens).||
-| `topics` or `topics.regex` |  For **topics**: Comma separated list of Kafka topics for Splunk to consume. `prod-topic1,prod-topc2,prod-topic3` <br/> For **topics.regex**: Use for declare topic subscriptions as name patterns, instead of specifying each topic in a list.<br/> **NOTE:** <br/> 1) If "topics.regex" is specified, the "topics" parameter must be omitted.<br/> 2) With "topics.regex", the Splunk meta fields("splunk.indexes", "splunk.sourcetypes", "splunk.sources") are ignored and should be omitted.<br/> 3) With "topics.regex" the Splunk metadata must either be defined on a per-event basis by using Kafak Header Fields("splunk.header.index", "splunk.header.sourcetype", etc.), OR it can be defined by the HEC token default index and sourcetype values.
+| `topics` or `topics.regex` |  For **topics**: Comma separated list of Kafka topics for Splunk to consume. `prod-topic1,prod-topc2,prod-topic3` <br/> For **topics.regex**: Use for declaring topic subscriptions as name pattern, instead of specifying each topic in a list. `^prod-topic[0-9]$`<br/> **NOTE:** <br/> 1) If "topics.regex" is specified, the "topics" parameter must be omitted.<br/> 2) With "topics.regex", the Splunk meta fields("splunk.indexes", "splunk.sourcetypes", "splunk.sources") are ignored and should be omitted.<br/> 3) With "topics.regex" the Splunk metadata must either be defined on a per-event basis by using Kafka Header Fields("splunk.header.index", "splunk.header.sourcetype", etc.), OR it can be defined by the HEC token default index and sourcetype values.
  
 #### General Optional Parameters
 | Name              | Description                | Default Value  |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Use the below schema to configure Splunk Connect for Kafka
 | `tasks.max` |  The number of tasks generated to handle data collection jobs in parallel. The tasks will be spread evenly across all Splunk Kafka Connector nodes.||
 | `splunk.hec.uri` | Splunk HEC URIs. Either a list of FQDNs or IPs of all Splunk indexers, separated with a ",", or a load balancer. The connector will load balance to indexers using round robin. Splunk Connector will round robin to this list of indexers. `https://hec1.splunk.com:8088,https://hec2.splunk.com:8088,https://hec3.splunk.com:8088`||
 | `splunk.hec.token` |  [Splunk Http Event Collector token](http://docs.splunk.com/Documentation/SplunkCloud/6.6.3/Data/UsetheHTTPEventCollector#About_Event_Collector_tokens).||
-| `topics` |  Comma separated list of Kafka topics for Splunk to consume. `prod-topic1,prod-topc2,prod-topic3`||
+| `topics` or `topics.regex` |  For **topics**: Comma separated list of Kafka topics for Splunk to consume. `prod-topic1,prod-topc2,prod-topic3` <br/> For **topics.regex**: Use for declare topic subscriptions as name patterns, instead of specifying each topic in a list.<br/> **NOTE:** <br/> 1) If "topics.regex" is specified, the "topics" parameter must be omitted.<br/> 2) With "topics.regex", the Splunk meta fields("splunk.indexes", "splunk.sourcetypes", "splunk.sources") are ignored and should be omitted.<br/> 3) With "topics.regex" the Splunk metadata must either be defined on a per-event basis by using Kafak Header Fields("splunk.header.index", "splunk.header.sourcetype", etc.), OR it can be defined by the HEC token default index and sourcetype values.
+ 
 #### General Optional Parameters
 | Name              | Description                | Default Value  |
 |--------           |----------------------------|-----------------------|

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -401,49 +401,43 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     }
 
     private Map<String, Map<String, String>> initMetaMap(Map<String, String> taskConfig) {
-        /* 
-        ** Modified 2021-08-28 by R. Vasaly to allow the use of 'topics.regex' instead
-        ** of the static list of topics. If topics.regex is specified in the config,
-        ** the Connector will subscribe to all matching topics. If topics.regex is used,
-        ** a single dummy entry is stored in the 'topics' string array so that existing
-        ** code does not fail with a null string. With the single dummy topic, mapping from
-        ** topic value to Splunk metadata will not work, so either the Headers must define
-        ** the Splunk metadata, or simply rely on the HEC token to set default index,
-        ** sourcetype, etc.
-        */
-        String[] topics = new String[1];
-        String[] topics_conf = split(taskConfig.get(SinkConnector.TOPICS_CONFIG), ",");
+        String[] topics = split(taskConfig.get(SinkConnector.TOPICS_CONFIG), ",");
         String[] topicIndexes = split(indexes, ",");
         String[] topicSourcetypes = split(sourcetypes, ",");
         String[] topicSources = split(sources, ",");
 
         Map<String, Map<String, String>> metaMap = new HashMap<>();
         int idx = 0;
-        // If the config has no "topics" values, set the array to a dummy entry
-        if (topics_conf == null || topics_conf.length == 0 || topics_conf[0].length() == 0) {
-        	topics[0] = "none";
-        } else {
-        	topics = topics_conf.clone();
-        }	
-        for (String topic: topics) {
-            HashMap<String, String> topicMeta = new HashMap<>();
-            String meta = getMetaForTopic(topicIndexes, topics.length, idx, INDEX_CONF);
-            if (meta != null) {
-                topicMeta.put(INDEX, meta);
-            }
+        /*
+        ** to allow the use of 'topics.regex' instead of the static list of topics.
+        ** If topics.regex is specified in the config, the Connector will subscribe to all matching topics.
+        ** If topics.regex is used, mapping from topic value to Splunk metadata will not work,
+        ** so either the Headers must define the Splunk metadata, or simply rely on the HEC token
+        ** to set default index, sourcetype, etc.
+        */
 
-            meta = getMetaForTopic(topicSourcetypes, topics.length, idx, SOURCETYPE_CONF);
-            if (meta != null) {
-                topicMeta.put(SOURCETYPE, meta);
-            }
+        // If the config has no "topics" values, skip metamap formation
+        if(topics != null && topics.length != 0) {
+            for (String topic : topics) {
+                HashMap<String, String> topicMeta = new HashMap<>();
+                String meta = getMetaForTopic(topicIndexes, topics.length, idx, INDEX_CONF);
+                if (meta != null) {
+                    topicMeta.put(INDEX, meta);
+                }
 
-            meta = getMetaForTopic(topicSources, topics.length, idx, SOURCE_CONF);
-            if (meta != null) {
-                topicMeta.put(SOURCE, meta);
-            }
+                meta = getMetaForTopic(topicSourcetypes, topics.length, idx, SOURCETYPE_CONF);
+                if (meta != null) {
+                    topicMeta.put(SOURCETYPE, meta);
+                }
 
-            metaMap.put(topic, topicMeta);
-            idx += 1;
+                meta = getMetaForTopic(topicSources, topics.length, idx, SOURCE_CONF);
+                if (meta != null) {
+                    topicMeta.put(SOURCE, meta);
+                }
+
+                metaMap.put(topic, topicMeta);
+                idx += 1;
+            }
         }
         return metaMap;
     }

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -214,8 +214,9 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(indexHeader != null) {
             headerString.append(indexHeader.value().toString());
         } else {
-            if(metas!=null)
-            headerString.append(metas.get("index"));
+            if(metas != null) {
+                headerString.append(metas.get("index"));
+            }
         }
 
         headerString.append(insertHeaderToken());
@@ -223,8 +224,9 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(hostHeader != null) {
             headerString.append(hostHeader.value().toString());
         } else {
-            if(metas!=null)
-            headerString.append("default-host");
+            if(metas != null) {
+                headerString.append("default-host");
+            }
         }
 
         headerString.append(insertHeaderToken());
@@ -232,8 +234,9 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(sourceHeader != null) {
             headerString.append(sourceHeader.value().toString());
         } else {
-            if(metas!=null)
-            headerString.append(metas.get("source"));
+            if(metas != null) {
+                headerString.append(metas.get("source"));
+            }
         }
 
         headerString.append(insertHeaderToken());
@@ -241,8 +244,9 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(sourcetypeHeader != null) {
             headerString.append(sourcetypeHeader.value().toString());
         } else {
-            if(metas!=null)
-            headerString.append(metas.get("sourcetype"));
+            if(metas != null) {
+                headerString.append(metas.get("sourcetype"));
+            }
         }
 
         headerString.append(insertHeaderToken());

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -214,6 +214,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(indexHeader != null) {
             headerString.append(indexHeader.value().toString());
         } else {
+            if(metas!=null)
             headerString.append(metas.get("index"));
         }
 
@@ -222,6 +223,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(hostHeader != null) {
             headerString.append(hostHeader.value().toString());
         } else {
+            if(metas!=null)
             headerString.append("default-host");
         }
 
@@ -230,6 +232,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(sourceHeader != null) {
             headerString.append(sourceHeader.value().toString());
         } else {
+            if(metas!=null)
             headerString.append(metas.get("source"));
         }
 
@@ -238,6 +241,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(sourcetypeHeader != null) {
             headerString.append(sourcetypeHeader.value().toString());
         } else {
+            if(metas!=null)
             headerString.append(metas.get("sourcetype"));
         }
 

--- a/src/test/java/com/splunk/kafka/connect/ConfigProfile.java
+++ b/src/test/java/com/splunk/kafka/connect/ConfigProfile.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public class ConfigProfile {
     private String topics;
+    private String topicsRegex;
     private String token;
     private String uri;
     private boolean raw;
@@ -49,6 +50,8 @@ public class ConfigProfile {
             case 2:  buildProfileTwo();
                      break;
             case 3:  buildProfileThree();
+                     break;
+            case 4:  buildProfileFour();
                      break;
             default: buildProfileDefault();
                      break;
@@ -183,12 +186,56 @@ public class ConfigProfile {
         return this;
     }
 
+    /*
+        Profile Four:
+        - Raw Endpoint
+        - with topics.regex
+    */
+    public ConfigProfile buildProfileFour() {
+        this.topicsRegex = "^kafka-data[0-9]$";
+        this.token = "mytoken";
+        this.uri = "https://dummy:8088";
+        this.raw = true;
+        this.ack = false;
+        this.indexes = "index-1";
+        this.sourcetypes = "kafka-data";
+        this.sources = "kafka-connect";
+        this.httpKeepAlive = true;
+        this.validateCertificates = false;
+        this.eventBatchTimeout = 1;
+        this.ackPollInterval = 1;
+        this.ackPollThreads = 1;
+        this.maxHttpConnPerChannel = 1;
+        this.totalHecChannels = 1;
+        this.socketTimeout = 1;
+        this.enrichements = "hello=world";
+        this.enrichementMap = new HashMap<>();
+        this.trackData = false;
+        this.maxBatchSize = 1;
+        this.numOfThreads = 1;
+        this.headerSupport = true;
+        this.headerIndex = "splunk.header.index";
+        this.headerSource = "splunk.header.source";
+        this.headerSourcetype = "splunk.header.sourcetype";
+        this.headerHost = "splunk.header.host";
+
+        return this;
+    }
+
     public String getTopics() {
         return topics;
     }
 
     public void setTopics(String topics) {
         this.topics = topics;
+    }
+
+    public String getTopicsRegex() {
+        return topicsRegex;
+    }
+
+    public void setTopicsRegex(String topicsRegex) {
+        this.topicsRegex = topicsRegex;
     }
 
     public String getToken() {
@@ -408,6 +455,6 @@ public class ConfigProfile {
     }
 
     @Override public String toString() {
-        return "ConfigProfile{" + "topics='" + topics + '\'' + ", token='" + token + '\'' + ", uri='" + uri + '\'' + ", raw=" + raw + ", ack=" + ack + ", indexes='" + indexes + '\'' + ", sourcetypes='" + sourcetypes + '\'' + ", sources='" + sources + '\'' + ", httpKeepAlive=" + httpKeepAlive + ", validateCertificates=" + validateCertificates + ", hasTrustStorePath=" + hasTrustStorePath + ", trustStorePath='" + trustStorePath + '\'' + ", trustStorePassword='" + trustStorePassword + '\'' + ", eventBatchTimeout=" + eventBatchTimeout + ", ackPollInterval=" + ackPollInterval + ", ackPollThreads=" + ackPollThreads + ", maxHttpConnPerChannel=" + maxHttpConnPerChannel + ", totalHecChannels=" + totalHecChannels + ", socketTimeout=" + socketTimeout + ", enrichements='" + enrichements + '\'' + ", enrichementMap=" + enrichementMap + ", trackData=" + trackData + ", maxBatchSize=" + maxBatchSize + ", numOfThreads=" + numOfThreads + '}';
+        return "ConfigProfile{" + "topics='" + topics + '\'' + ", topics.regex='" + topicsRegex +  '\'' + ", token='" + token + '\'' + ", uri='" + uri + '\'' + ", raw=" + raw + ", ack=" + ack + ", indexes='" + indexes + '\'' + ", sourcetypes='" + sourcetypes + '\'' + ", sources='" + sources + '\'' + ", httpKeepAlive=" + httpKeepAlive + ", validateCertificates=" + validateCertificates + ", hasTrustStorePath=" + hasTrustStorePath + ", trustStorePath='" + trustStorePath + '\'' + ", trustStorePassword='" + trustStorePassword + '\'' + ", eventBatchTimeout=" + eventBatchTimeout + ", ackPollInterval=" + ackPollInterval + ", ackPollThreads=" + ackPollThreads + ", maxHttpConnPerChannel=" + maxHttpConnPerChannel + ", totalHecChannels=" + totalHecChannels + ", socketTimeout=" + socketTimeout + ", enrichements='" + enrichements + '\'' + ", enrichementMap=" + enrichementMap + ", trackData=" + trackData + ", maxBatchSize=" + maxBatchSize + ", numOfThreads=" + numOfThreads + '}';
     }
 }

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -20,6 +20,7 @@ import com.splunk.hecclient.HecConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.sink.SinkConnector;
 
+import org.apache.kafka.connect.sink.SinkTask;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -240,13 +241,29 @@ public class SplunkSinkConnectorConfigTest {
 
     @Test
     public void createWithEmptyTopicMetaData() {
-        UnitUtil uu = new UnitUtil(0);
+        UnitUtil uu = new UnitUtil(4);
 
         // when topics.regex value use in config then skip formation of topicMeta
         Map<String, String> config = uu.createTaskConfig();
-        config.put(SinkConnector.TOPICS_CONFIG, "");
         SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
         Assert.assertEquals(0, connectorConfig.topicMetas.size());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testTopicsAndTopicsRegexCombination() {
+        UnitUtil uu = new UnitUtil(4);
+        Map<String, String> config = uu.createTaskConfig();
+        config.put(SinkConnector.TOPICS_CONFIG, "topic1");
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testEmptyTopicsAndTopicsRegexCombination() {
+        UnitUtil uu = new UnitUtil(4);
+        Map<String, String> config = uu.createTaskConfig();
+        config.put(SinkConnector.TOPICS_CONFIG, "");
+        config.put(SinkTask.TOPICS_REGEX_CONFIG, "");
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
     }
 
     @Test

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -239,6 +239,17 @@ public class SplunkSinkConnectorConfigTest {
     }
 
     @Test
+    public void createWithEmptyTopicMetaData() {
+        UnitUtil uu = new UnitUtil(0);
+
+        // when topics.regex value use in config then skip formation of topicMeta
+        Map<String, String> config = uu.createTaskConfig();
+        config.put(SinkConnector.TOPICS_CONFIG, "");
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
+        Assert.assertEquals(0, connectorConfig.topicMetas.size());
+    }
+
+    @Test
     public void toStr() {
         UnitUtil uu = new UnitUtil(0);
 

--- a/src/test/java/com/splunk/kafka/connect/UnitUtil.java
+++ b/src/test/java/com/splunk/kafka/connect/UnitUtil.java
@@ -16,6 +16,7 @@
 package com.splunk.kafka.connect;
 
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.sink.SinkTask;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +32,7 @@ public class UnitUtil {
     public Map<String, String> createTaskConfig() {
         Map<String, String> config = new HashMap<>();
         config.put(SinkConnector.TOPICS_CONFIG, configProfile.getTopics());
+        config.put(SinkTask.TOPICS_REGEX_CONFIG, configProfile.getTopicsRegex());
         config.put(SplunkSinkConnectorConfig.TOKEN_CONF, configProfile.getToken());
         config.put(SplunkSinkConnectorConfig.URI_CONF, configProfile.getUri());
         config.put(SplunkSinkConnectorConfig.RAW_CONF, String.valueOf(configProfile.isRaw()));


### PR DESCRIPTION
Enable topics.regex to be used to declare topic subscriptions as name patterns, instead of specifying each topic in a list 