### PR TITLE
Handled case to clear tracker where event is not added to the LinkedBlockingQueue if its full.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Splunk Connect for Kafka
+## Splunk Connect for Kafka test
 
 Splunk Connect for Kafka is a Kafka Connect Sink for Splunk with the following features:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Splunk Connect for Kafka test
+## Splunk Connect for Kafka
 
 Splunk Connect for Kafka is a Kafka Connect Sink for Splunk with the following features:
 

--- a/src/main/java/com/splunk/hecclient/ConcurrentHec.java
+++ b/src/main/java/com/splunk/hecclient/ConcurrentHec.java
@@ -57,7 +57,11 @@ public class ConcurrentHec implements HecInf {
     @Override
     public final void send(final EventBatch batch) {
         try {
-            batches.offer(batch, 1000, TimeUnit.MILLISECONDS);
+            boolean offerSuccess = batches.offer(batch, 1000, TimeUnit.MILLISECONDS);
+            if (!offerSuccess) {
+                log.warn("Linked blocking queue is full (size = {}) for event batch = {}, failed to offer batch into queue", batches.size(), batch.getUUID());
+                throw new HecException("linked blocking event queue is full, failed to offer batch into queue");
+            }
         } catch (InterruptedException ex) {
             throw new HecException("failed to offer batch into queue", ex);
         }


### PR DESCRIPTION
Handled case to clear tracker where event is not added to the LinkedBlockingQueue if its full.

Get the boolean flag of offer method of LinkeBlockingQueue.
Check if it is 'false'
then Throw HecExcpetion so that it is added to the failed event list so that it can be retried.