### PR TITLE
Uri validator bug

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -41,6 +41,7 @@ import org.apache.kafka.connect.sink.SinkConnector;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -170,7 +171,8 @@ public final class SplunkSinkConnector extends SinkConnector {
             };
         }
         String endpoint = "/services/collector";
-        String url = connectorConfig.splunkURI + endpoint;
+        List<String> hecURIs = Arrays.asList(connectorConfig.splunkURI.split(","));
+        String url = hecURIs.get(0) + endpoint;
         final HttpPost httpPost = new HttpPost(url);
         httpPost.setHeaders(headers);
         EventBatch batch = new JsonEventBatch();

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -208,6 +208,21 @@ class SplunkSinkConnecterTest {
     }
 
     @Test
+    public void testValidMultipleURIs() {
+        final Map<String, String> configs = new HashMap<>();
+        addNecessaryConfigs(configs);
+        SplunkSinkConnector connector = new SplunkSinkConnector();
+        configs.put("topics", "b");
+        configs.put("splunk.indexes", "b");
+        configs.put("splunk.hec.uri", "https://localhost:8088,https://localhost:8089");
+        configs.put("splunk.hec.ssl.validate.certs", "false");
+        MockHecClientWrapper clientInstance = new MockHecClientWrapper();
+        clientInstance.client.setResponse(CloseableHttpClientMock.success);
+        ((SplunkSinkConnector) connector).setHecInstance(clientInstance);
+        Assertions.assertDoesNotThrow(()->connector.validate(configs));
+    }
+
+    @Test
     public void testValidSplunkConfigurations() {
         final Map<String, String> configs = new HashMap<>();
         addNecessaryConfigs(configs);


### PR DESCRIPTION
Fixes https://github.com/splunk/kafka-connect-splunk/issues/375 which outlined a bug with the new config validation.

The `splunk.hec.uri` can be either a single URI or a comma-separated list. This PR updates the config validation to split the URI on `,` like we do in configuration processing, and then use the first URI to validate.

I think this could potentially run into edge cases where you've mixed http and https URIs in the `splunk.hec.uri` setting, though if you're doing this maybe you don't really want validation anyways.

Added a test case which errored before the change and passed after, hopefully this is sufficient to un-break `v2.1.0`.

/cc @deep-splunk @harshit-splunk 