### PR TITLE
bump guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>32.0-jre</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR bumps `guava` from `30.1` to `32.0.1` to remediate [CVE-2023-2976](https://github.com/advisories/GHSA-7g45-4rm6-3mm3).