### PR TITLE
added a timestamp.timezone configuration in SplunkSinkConnectorConfig…

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.splunk.kafka.connect</groupId>
   <artifactId>splunk-kafka-connect</artifactId>
   <name>splunk-kafka-connect</name>
-  <version>v2.1.0</version>
+  <version>v2.1.2</version>
   <build>
     <plugins>
       <plugin>
@@ -107,6 +107,12 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <url>https://packages.confluent.io/maven/</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>splunk-kafka-connect</artifactId>
-    <version>v2.1.0</version>
+    <version>v2.1.2</version>
     <name>splunk-kafka-connect</name>
 
     <properties>

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -95,6 +95,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
      static final String ENABLE_TIMESTAMP_EXTRACTION_CONF = "enable.timestamp.extraction";
      static final String REGEX_CONF = "timestamp.regex";
      static final String TIMESTAMP_FORMAT_CONF = "timestamp.format";
+     static final String TIMESTAMP_TIMEZONE_CONF = "timestamp.timezone";
 
     // Kafka configuration description strings
     // Required Parameters
@@ -202,6 +203,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     static final String ENABLE_TIMESTAMP_EXTRACTION_DOC = "Set to true if you want to extract the timestamp";
     static final String REGEX_DOC = "Regex";
     static final String TIMESTAMP_FORMAT_DOC = "Timestamp format";
+    static final String TIMESTAMP_TIMEZONE_DOC = "Timestamp timezone";
 
     final String splunkToken;
     final String splunkURI;
@@ -258,6 +260,8 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     final String regex;
     final String timestampFormat;
 
+    final String timeZone;
+
     SplunkSinkConnectorConfig(Map<String, String> taskConfig) {
         super(conf(), taskConfig);
         splunkToken = getPassword(TOKEN_CONF).value();
@@ -311,6 +315,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         enableTimestampExtraction = getBoolean(ENABLE_TIMESTAMP_EXTRACTION_CONF);
         regex = getString(REGEX_CONF);
         timestampFormat = getString(TIMESTAMP_FORMAT_CONF).trim();
+        timeZone = getString(TIMESTAMP_TIMEZONE_CONF);
         validateRegexForTimestamp(regex);
       
     }
@@ -360,7 +365,8 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(KERBEROS_KEYTAB_PATH_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, KERBEROS_KEYTAB_LOCATION_DOC)
                 .define(ENABLE_TIMESTAMP_EXTRACTION_CONF, ConfigDef.Type.BOOLEAN,  false , ConfigDef.Importance.MEDIUM, ENABLE_TIMESTAMP_EXTRACTION_DOC)
                 .define(REGEX_CONF, ConfigDef.Type.STRING,  "" , ConfigDef.Importance.MEDIUM, REGEX_DOC)
-                .define(TIMESTAMP_FORMAT_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, TIMESTAMP_FORMAT_DOC);         
+                .define(TIMESTAMP_FORMAT_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, TIMESTAMP_FORMAT_DOC)
+                .define(TIMESTAMP_TIMEZONE_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, TIMESTAMP_TIMEZONE_DOC);
     }
 
     /**

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -578,9 +578,12 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
                 log.warn("Could not set the time", e);
             }
         } else {
-            SimpleDateFormat df = new SimpleDateFormat(connectorConfig.timestampFormat);
+            SimpleDateFormat df = new SimpleDateFormat(connectorConfig.timestampFormat,Locale.ENGLISH);
             Date date;
             try {
+                if(!connectorConfig.timeZone.isEmpty())
+                    df.setTimeZone(TimeZone.getTimeZone(connectorConfig.timeZone));
+
                 date = df.parse(timestamp);
                 event.setTime(date.getTime() / 1000.0);
             } catch (ParseException e) {

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
@@ -257,6 +257,7 @@ public class SplunkSinkTaskTest {
         config.put(SplunkSinkConnectorConfig.ENABLE_TIMESTAMP_EXTRACTION_CONF, String.valueOf(true));
         config.put(SplunkSinkConnectorConfig.REGEX_CONF, "\\\"time\\\":\\s*\\\"(?<time>.*?)\"");
         config.put(SplunkSinkConnectorConfig.TIMESTAMP_FORMAT_CONF, "MMM dd yyyy HH:mm:ss.SSS zzz");
+//        config.put(SplunkSinkConnectorConfig.TIMESTAMP_TIMEZONE_CONF, "");
         HecMock hec = new HecMock(task);
         hec.setSendReturnResult(HecMock.success);
         task.setHec(hec);


### PR DESCRIPTION
I have the same issue "Add support for timezone override #398", so I added a timestamp.timezone.
as a default it's the UTC, but in my case I needed to change UTC to Asia/Seoul.
