### PR TITLE
fix: fix incorrect logging

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -313,7 +313,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         } catch (Exception ex) {
             batch.fail();
             onEventFailure(Arrays.asList(batch), ex);
-            log.error("failed to send batch {}" ,batch.getUUID(), ex);
+            log.error(String.format("failed to send batch %s", batch.getUUID()), ex);
         }
     }
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,6 @@
-cython < 3.0.0
 pytest
 requests == 2.28.2
 kafka-python
-pyyaml == 5.4.1
+pyyaml == 5.3.1
 jinja2
 jsonpath


### PR DESCRIPTION
https://github.com/splunk/kafka-connect-splunk/blob/95adc9c87a53b0b6c4f337c51faafd02a258035f/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java#L316 used incorrect method to log the exception, use the correct one as per doc.