### PR TITLE
chore: add support for latest kafka versions

### DIFF
--- a/.github/workflows/ci_build_test.yaml
+++ b/.github/workflows/ci_build_test.yaml
@@ -136,6 +136,10 @@ jobs:
             kafka_package: "kafka_2.13-3.1.0.tgz"
           - kafka_version: "3.3.1"
             kafka_package: "kafka_2.13-3.3.1.tgz"
+          - kafka_version: "3.4.1"
+            kafka_package: "kafka_2.13-3.4.1.tgz"
+          - kafka_version: "3.5.1"
+            kafka_package: "kafka_2.13-3.5.1.tgz"
     env:
       CI_SPLUNK_VERSION: "9.0.2"
       CI_SPLUNK_FILENAME: splunk-9.0.2-17e00c557dc1-Linux-x86_64.tgz

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Splunk Connect for Kafka is a Kafka Connect Sink for Splunk with the following f
 
 ## Requirements
 1. Kafka version 1.0.0 and above. 
-   * Tested with following versions: 1.1.1, 2.0.0, 2.1.0, 2.6.0, 2.7.1, 2.8.0, 3.0.0, 3.1.0, 3.3.1
+   * Tested with following versions: 1.1.1, 2.0.0, 2.1.0, 2.6.0, 2.7.1, 2.8.0, 3.0.0, 3.1.0, 3.3.1, 3.4.1, 3.5.1
 2. Java 8 and above.
 3. A Splunk environment of version 8.0.0 and above, configured with valid HTTP Event Collector (HEC) tokens.
 


### PR DESCRIPTION
update CI with kafka 3.4.1 and 3.5.1