### PR TITLE
Fix potential NullPointerException for Kafka headers with null value

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -222,7 +222,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
 
         StringBuilder headerString = new StringBuilder();
 
-        if(indexHeader != null) {
+        if(indexHeader != null && indexHeader.value() != null) {
             headerString.append(indexHeader.value().toString());
         } else {
             if(metas != null) {
@@ -232,7 +232,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
 
         headerString.append(insertHeaderToken());
 
-        if(hostHeader != null) {
+        if(hostHeader != null && hostHeader.value() != null) {
             headerString.append(hostHeader.value().toString());
         } else {
             if(metas != null) {
@@ -242,7 +242,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
 
         headerString.append(insertHeaderToken());
 
-        if(sourceHeader != null) {
+        if(sourceHeader != null && sourceHeader.value() != null) {
             headerString.append(sourceHeader.value().toString());
         } else {
             if(metas != null) {
@@ -252,7 +252,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
 
         headerString.append(insertHeaderToken());
 
-        if(sourcetypeHeader != null) {
+        if(sourcetypeHeader != null && sourcetypeHeader.value() != null) {
             headerString.append(sourcetypeHeader.value().toString());
         } else {
             if(metas != null) {
@@ -450,16 +450,16 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         Header headerSource = headers.lastWithName(connectorConfig.headerSource);
         Header headerSourcetype = headers.lastWithName(connectorConfig.headerSourcetype);
 
-        if (headerIndex != null) {
+        if (headerIndex != null && headerIndex.value() != null) {
             event.setIndex(headerIndex.value().toString());
         }
-        if (headerHost != null) {
+        if (headerHost != null && headerHost.value() != null) {
             event.setHost(headerHost.value().toString());
         }
-        if (headerSource != null) {
+        if (headerSource != null && headerSource.value() != null) {
             event.setSource(headerSource.value().toString());
         }
-        if (headerSourcetype != null) {
+        if (headerSourcetype != null && headerSourcetype.value() != null) {
             event.setSourcetype(headerSourcetype.value().toString());
         }
 

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
@@ -17,19 +17,17 @@ package com.splunk.kafka.connect;
 
 import com.splunk.hecclient.Event;
 import com.splunk.hecclient.EventBatch;
-import com.splunk.hecclient.JsonEvent;
 import com.splunk.hecclient.RawEventBatch;
-import org.apache.commons.logging.Log;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.text.ParseException;
 import java.util.*;
 
 public class SplunkSinkTaskTest {
@@ -243,6 +241,25 @@ public class SplunkSinkTaskTest {
     }
 
     @Test
+    public void putWithNullIndexHeaderValue() {
+        UnitUtil uu = new UnitUtil(0);
+        Map<String, String> config = uu.createTaskConfig();
+        config.put(SplunkSinkConnectorConfig.RAW_CONF, String.valueOf(true));
+        config.put(SplunkSinkConnectorConfig.ACK_CONF, String.valueOf(true));
+        config.put(SplunkSinkConnectorConfig.MAX_BATCH_SIZE_CONF, String.valueOf(1));
+        config.put(SplunkSinkConnectorConfig.HEADER_SUPPORT_CONF, String.valueOf("true"));
+        config.put(SplunkSinkConnectorConfig.HEADER_INDEX_CONF, "index");
+        SplunkSinkTask task = new SplunkSinkTask();
+        HecMock hec = new HecMock(task);
+        hec.setSendReturnResult(HecMock.success);
+        task.setHec(hec);
+        task.start(config);
+        task.put(createSinkRecordWithNullIndexHeaderValue());
+        Assert.assertEquals(1, hec.getBatches().size());
+        task.stop();
+    }
+
+    @Test
     public void putWithRawAndAck() {
         putWithSuccess(true, true);
     }
@@ -452,6 +469,12 @@ public class SplunkSinkTaskTest {
         List<SinkRecord> records = new ArrayList<>();
         SinkRecord rec = null;
         records.add(rec);
+        return records;
+    }
+
+    private Collection<SinkRecord> createSinkRecordWithNullIndexHeaderValue() {
+        List<SinkRecord> records = new ArrayList<>(createSinkRecords(1));
+        records.get(0).headers().add("index", null, null);
         return records;
     }
 


### PR DESCRIPTION
In Kafka Connect, a message Header value can be null, so additional null-checks are required when processing header values e.g. for the Splunk index, to avoid an NPE in `headerId` and elsewhere e.g.:

```
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:622)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:334)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:235)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:204)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:201)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:256)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NullPointerException: Cannot invoke "Object.toString()" because the return value of "org.apache.kafka.connect.header.Header.value()" is null
        at com.splunk.kafka.connect.SplunkSinkTask.headerId(SplunkSinkTask.java:226)
        at com.splunk.kafka.connect.SplunkSinkTask.handleRecordsWithHeader(SplunkSinkTask.java:190)
        at com.splunk.kafka.connect.SplunkSinkTask.handleRaw(SplunkSinkTask.java:170)
        at com.splunk.kafka.connect.SplunkSinkTask.put(SplunkSinkTask.java:110)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:588)
        ... 10 more
```

Adds a failing -> passing test, when operating in HEC raw mode, with header support enabled.