### PR TITLE
fix: fix bug while dealing with raw events, increase coverage

### DIFF
--- a/src/main/java/com/splunk/hecclient/HecURIBuilder.java
+++ b/src/main/java/com/splunk/hecclient/HecURIBuilder.java
@@ -1,6 +1,8 @@
 package com.splunk.hecclient;
 
+import org.apache.http.Consts;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -18,9 +20,18 @@ public class HecURIBuilder {
 
     public URI getURI(String endpoint) {
         try {
-            URIBuilder uriBuilder = new URIBuilder(baseUrl)
-                    .setPath(endpoint);
-
+            URIBuilder uriBuilder = new URIBuilder(baseUrl);
+            int idx = endpoint.indexOf('?');
+            if (idx == -1) {
+                // json endpoint
+                uriBuilder = uriBuilder.setPath(endpoint);
+            } else {
+                // in case of raw endpoint, the endpoint will be in form "/services/collector/raw?index=xxx&source=xxx"
+                // extract the path and params via a split on '?'
+                uriBuilder = uriBuilder.setPath(endpoint.substring(0, idx));
+                uriBuilder = uriBuilder.setParameters(URLEncodedUtils.parse(endpoint.substring(idx+1), Consts.UTF_8));
+            }
+            
             if (hecConfig.getAutoExtractTimestamp() != null) {
                 uriBuilder.addParameter(AUTO_EXTRACT_TIMESTAMP_PARAMETER, hecConfig.getAutoExtractTimestamp().toString());
             }

--- a/src/test/java/com/splunk/hecclient/HecURIBuilderTest.java
+++ b/src/test/java/com/splunk/hecclient/HecURIBuilderTest.java
@@ -9,17 +9,28 @@ import java.util.Collections;
 import static com.splunk.hecclient.JsonEventBatch.ENDPOINT;
 
 public class HecURIBuilderTest {
+    private static final String RAW_ENDPOINT = "/services/collector/raw?index=main&source=source";
     private static final String BASE_URL =  "https://localhost:8088";
     private static final String TOKEN =  "mytoken";
 
     @Test
     public void testDefaultValues() {
-        HecConfig hecConfig = new HecConfig(Collections.emptyList(), TOKEN);
-        HecURIBuilder builder = new HecURIBuilder(BASE_URL, hecConfig);
+        {
+            HecConfig hecConfig = new HecConfig(Collections.emptyList(), TOKEN);
+            HecURIBuilder builder = new HecURIBuilder(BASE_URL, hecConfig);
 
-        URI uri = builder.getURI(ENDPOINT);
+            URI uri = builder.getURI(ENDPOINT);
 
-        Assert.assertEquals("https://localhost:8088/services/collector/event", uri.toString());
+            Assert.assertEquals("https://localhost:8088/services/collector/event", uri.toString());
+        }
+        {
+            HecConfig hecConfig = new HecConfig(Collections.emptyList(), TOKEN);
+            HecURIBuilder builder = new HecURIBuilder(BASE_URL, hecConfig);
+
+            URI uri = builder.getURI(RAW_ENDPOINT);
+
+            Assert.assertEquals("https://localhost:8088/services/collector/raw?index=main&source=source", uri.toString());
+        }
     }
 
     @Test
@@ -44,6 +55,28 @@ public class HecURIBuilderTest {
 
             Assert.assertEquals("https://localhost:8088/services/collector/event?" +
                             HecURIBuilder.AUTO_EXTRACT_TIMESTAMP_PARAMETER + "=false",
+                    uri.toString());
+        }
+        {
+            HecConfig hecConfig = new HecConfig(Collections.emptyList(), TOKEN)
+                    .setAutoExtractTimestamp(false);
+            HecURIBuilder builder = new HecURIBuilder(BASE_URL, hecConfig);
+
+            URI uri = builder.getURI(RAW_ENDPOINT);
+
+            Assert.assertEquals("https://localhost:8088/services/collector/raw?index=main&source=source&" +
+                            HecURIBuilder.AUTO_EXTRACT_TIMESTAMP_PARAMETER + "=false",
+                    uri.toString());
+        }
+        {
+            HecConfig hecConfig = new HecConfig(Collections.emptyList(), TOKEN)
+                    .setAutoExtractTimestamp(true);
+            HecURIBuilder builder = new HecURIBuilder(BASE_URL, hecConfig);
+
+            URI uri = builder.getURI(RAW_ENDPOINT);
+
+            Assert.assertEquals("https://localhost:8088/services/collector/raw?index=main&source=source&" +
+                            HecURIBuilder.AUTO_EXTRACT_TIMESTAMP_PARAMETER + "=true",
                     uri.toString());
         }
     }


### PR DESCRIPTION
- while dealing with raw events, url builder esaceps `?`.
- To counter this, split the URL from `?` and merge both the parts via setParameters()