### PR TITLE
added trim to topic names to remove leading whitespace if exists

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -527,7 +527,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                     topicMeta.put(SOURCE, meta);
                 }
 
-                metaMap.put(topic, topicMeta);
+                metaMap.put(topic.trim(), topicMeta);
                 idx += 1;
             }
         }


### PR DESCRIPTION
## Problem
If multiple topics are provided in the list with an intention to write data to corresponding index, example:
"topics":` "splunk-qs, splunk-abc", 
"splunk.indexes": "index1,index2",

the leading space before  splunk-abc will cause the mapping to not work and instead of writing to index2, the connector will write all messages from splunk-abc topic to default index (main).

## Solution

Trim topic name before adding it to the map

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
