### PR TITLE
update kafka.version to fix vulnerability

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -209,7 +209,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <junit.jupiter.version>5.9.2</junit.jupiter.version>
     <jackson.version>2.18.6</jackson.version>
-    <kafka.version>3.9.1</kafka.version>
+    <kafka.version>3.9.2</kafka.version>
     <junit.platform.version>1.9.2</junit.platform.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>2.0.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <junit.vintage.version>5.9.2</junit.vintage.version>
         <junit.platform.version>1.9.2</junit.platform.version>
         <jackson.version>2.18.6</jackson.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <slf4j.version>2.0.7</slf4j.version>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>


### PR DESCRIPTION
Updated the Kafka dependency pin from 3.9.1 to 3.9.2 in pom.xml and dependency-reduced-pom.xml to address CVE-2026-33558