### PR TITLE
fix: use the ssl options in http builder when using kerberos

### DIFF
--- a/src/main/java/com/splunk/hecclient/Hec.java
+++ b/src/main/java/com/splunk/hecclient/Hec.java
@@ -266,41 +266,40 @@ public class Hec implements HecInf {
     */
     public static CloseableHttpClient createHttpClient(final HecConfig config) {
         int poolSizePerDest = config.getMaxHttpConnectionPerChannel();
+        HttpClientBuilder builder = new HttpClientBuilder()
+            .setDisableSSLCertVerification(config.getDisableSSLCertVerification())
+            .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
+            .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size());
+
+        if (hasCustomTrustStoreConfig(config)) {
+            SSLContext context = loadCustomSSLContext(
+                config.getTrustStorePath(),
+                config.getTrustStoreType(),
+                config.getTrustStorePassword()
+            );
+
+            if (context == null) {
+                // failure configuring SSL Context created from trust store path and password values
+                throw new HecException("trust store path provided but failed to initialize ssl context");
+            }
+            builder.setSslContext(context);
+        }
 
         if (config.kerberosAuthEnabled()) {
             try {
-              return new HttpClientBuilder().buildKerberosClient();
+                return builder.buildKerberosClient();
             } catch (KeyStoreException | NoSuchAlgorithmException | KeyManagementException ex) {
-              throw new ConnectException("Unable to build Kerberos Client", ex);
+                throw new ConnectException("Unable to build Kerberos Client", ex);
             }
-          }
-
-        // Code block for default client construction
-        if(!config.getHasCustomTrustStore() &&
-           StringUtils.isBlank(config.getTrustStorePath()) &&
-           StringUtils.isBlank(config.getTrustStorePassword())) {  // no trust store path or password provided via config
-
-            return new HttpClientBuilder().setDisableSSLCertVerification(config.getDisableSSLCertVerification())
-                    .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
-                    .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size())
-                    .build();
         }
 
-        // Code block for custom keystore client construction
-        SSLContext context = loadCustomSSLContext(config.getTrustStorePath(), config.getTrustStoreType(), config.getTrustStorePassword());
+        return builder.build();
+    }
 
-        if (context != null) {
-            return new HttpClientBuilder()
-                .setDisableSSLCertVerification(config.getDisableSSLCertVerification())
-                .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
-                .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size())
-                .setSslContext(context)
-                .build();
-        }
-        else {
-             //failure configuring SSL Context created from trust store path and password values
-             throw new HecException("trust store path provided but failed to initialize ssl context");
-         }
+    private static boolean hasCustomTrustStoreConfig(final HecConfig config) {
+        return config.getHasCustomTrustStore()
+            || StringUtils.isNotBlank(config.getTrustStorePath())
+            || StringUtils.isNotBlank(config.getTrustStorePassword());
     }
 
    /**

--- a/src/main/java/com/splunk/hecclient/Hec.java
+++ b/src/main/java/com/splunk/hecclient/Hec.java
@@ -252,24 +252,20 @@ public class Hec implements HecInf {
     }
 
    /**
-    * createHttpClient will construct 2 different versions of the a CloseableHttpClient depending on whether a custom
-    * trust store is to be used or a default configuration is substantial enough. When a trust store path and password
-    * is provided createHttpClient will build an SSL Context to be used with the HTTP Client from the Keystore provided
-    * in conjunction with a default TrustManager.
+    * Creates a CloseableHttpClient using either the default SSL configuration or a custom trust store configuration.
+    * When a trust store path and password are provided, createHttpClient builds an SSL context from the provided
+    * key store and default TrustManager.
     *
-    * @param config Hec Configuration used to construct
+    * @param config Hec configuration used to construct the HTTP client
     * @since        1.0.0
     * @throws       HecException
-    * @return       A configured CloseableHTTPClient customized to the settings proved through config.
+    * @return       A configured CloseableHTTPClient customized to the settings provided through config.
     * @see          CloseableHttpClient
     * @see          HecException
     */
     public static CloseableHttpClient createHttpClient(final HecConfig config) {
-        int poolSizePerDest = config.getMaxHttpConnectionPerChannel();
-        HttpClientBuilder builder = new HttpClientBuilder()
-            .setDisableSSLCertVerification(config.getDisableSSLCertVerification())
-            .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
-            .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size());
+
+        HttpClientBuilder builder = configureSSL(new HttpClientBuilder(), config);
 
         if (hasCustomTrustStoreConfig(config)) {
             SSLContext context = loadCustomSSLContext(
@@ -300,6 +296,14 @@ public class Hec implements HecInf {
         return config.getHasCustomTrustStore()
             || StringUtils.isNotBlank(config.getTrustStorePath())
             || StringUtils.isNotBlank(config.getTrustStorePassword());
+    }
+
+    private static HttpClientBuilder configureSSL(HttpClientBuilder httpClientBuilder, HecConfig config) {
+        int poolSizePerDest = config.getMaxHttpConnectionPerChannel();
+        httpClientBuilder.setDisableSSLCertVerification(config.getDisableSSLCertVerification())
+                .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
+                .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size());
+        return httpClientBuilder;
     }
 
    /**

--- a/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
+++ b/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
@@ -28,7 +28,6 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Lookup;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.config.SocketConfig;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.auth.SPNegoSchemeFactory;
@@ -108,6 +107,13 @@ public final class HttpClientBuilder {
         Lookup<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create().
             register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true)).build();
         builder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
+        SocketConfig config = SocketConfig.custom()
+                .setSndBufSize(socketSendBufferSize)
+                .setSoTimeout(socketTimeout * 1000)
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
         BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(new AuthScope(null, -1, null), new Credentials() {
             @Override
@@ -120,15 +126,17 @@ public final class HttpClientBuilder {
             }
         });
         builder.setDefaultCredentialsProvider(credentialsProvider);
-        SSLContextBuilder sslContextBuilderbuilder = new SSLContextBuilder();
-        sslContextBuilderbuilder.loadTrustMaterial(null, (chain, authType) -> true);
-        SSLConnectionSocketFactory sslsf = new
-            SSLConnectionSocketFactory(
-            sslContextBuilderbuilder.build(), NoopHostnameVerifier.INSTANCE);
+        SSLConnectionSocketFactory sslsf = getSSLConnectionFactory();
 
-        builder.setSSLSocketFactory(sslsf);
-        CloseableHttpClient httpClient = builder.build();
-        return httpClient;
+        if (sslsf != null) {
+            builder.setSSLSocketFactory(sslsf);
+        }
+        return builder.useSystemProperties()
+                .setMaxConnPerRoute(maxConnectionPoolSizePerDestination)
+                .setMaxConnTotal(maxConnectionPoolSize)
+                .setDefaultSocketConfig(config)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
     }
 
 

--- a/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
+++ b/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
@@ -82,63 +82,67 @@ public final class HttpClientBuilder {
     }
 
     public CloseableHttpClient build() {
-        SSLConnectionSocketFactory sslFactory = getSSLConnectionFactory();
-        SocketConfig config = SocketConfig.custom()
-                .setSndBufSize(socketSendBufferSize)
-                .setSoTimeout(socketTimeout * 1000)
-                .build();
-        RequestConfig requestConfig = RequestConfig.custom()
-                .setCookieSpec(CookieSpecs.STANDARD)
-                .build();
-
-        return HttpClients.custom()
-                .useSystemProperties()
-                .setSSLSocketFactory(sslFactory)
-                .setMaxConnPerRoute(maxConnectionPoolSizePerDestination)
-                .setMaxConnTotal(maxConnectionPoolSize)
-                .setDefaultSocketConfig(config)
-                .setDefaultRequestConfig(requestConfig)
-                .build();
+        return createHttpClientBuilder().build();
     }
 
     public CloseableHttpClient buildKerberosClient() throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        org.apache.http.impl.client.HttpClientBuilder builder =
-            org.apache.http.impl.client.HttpClientBuilder.create();
-        Lookup<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create().
-            register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true)).build();
-        builder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
-        SocketConfig config = SocketConfig.custom()
+        org.apache.http.impl.client.HttpClientBuilder builder = createHttpClientBuilder();
+        configureKerberos(builder);
+        return builder.build();
+    }
+
+    private org.apache.http.impl.client.HttpClientBuilder createHttpClientBuilder() {
+        org.apache.http.impl.client.HttpClientBuilder builder = HttpClients.custom()
+                .useSystemProperties()
+                .setMaxConnPerRoute(maxConnectionPoolSizePerDestination)
+                .setMaxConnTotal(maxConnectionPoolSize)
+                .setDefaultSocketConfig(createSocketConfig())
+                .setDefaultRequestConfig(createRequestConfig());
+
+        SSLConnectionSocketFactory sslFactory = getSSLConnectionFactory();
+        if (sslFactory != null) {
+            builder.setSSLSocketFactory(sslFactory);
+        }
+
+        return builder;
+    }
+
+    private SocketConfig createSocketConfig() {
+        return SocketConfig.custom()
                 .setSndBufSize(socketSendBufferSize)
                 .setSoTimeout(socketTimeout * 1000)
                 .build();
-        RequestConfig requestConfig = RequestConfig.custom()
+    }
+
+    private RequestConfig createRequestConfig() {
+        return RequestConfig.custom()
                 .setCookieSpec(CookieSpecs.STANDARD)
                 .build();
+    }
+
+    private void configureKerberos(org.apache.http.impl.client.HttpClientBuilder builder) {
+        Lookup<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
+                .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true))
+                .build();
+        builder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
+        builder.setDefaultCredentialsProvider(createKerberosCredentialsProvider());
+    }
+
+    private BasicCredentialsProvider createKerberosCredentialsProvider() {
         BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(new AuthScope(null, -1, null), new Credentials() {
             @Override
             public Principal getUserPrincipal() {
                 return null;
             }
+
             @Override
             public String getPassword() {
                 return null;
             }
         });
-        builder.setDefaultCredentialsProvider(credentialsProvider);
-        SSLConnectionSocketFactory sslsf = getSSLConnectionFactory();
-
-        if (sslsf != null) {
-            builder.setSSLSocketFactory(sslsf);
-        }
-        return builder.useSystemProperties()
-                .setMaxConnPerRoute(maxConnectionPoolSizePerDestination)
-                .setMaxConnTotal(maxConnectionPoolSize)
-                .setDefaultSocketConfig(config)
-                .setDefaultRequestConfig(requestConfig)
-                .build();
+        return credentialsProvider;
     }
-
 
     private SSLConnectionSocketFactory getSSLConnectionFactory() {
         if (disableSSLCertVerification) {

--- a/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
+++ b/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
@@ -15,12 +15,29 @@
  */
 package com.splunk.hecclient;
 
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import java.io.FileInputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.Collections;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 
 public class HttpClientBuilderTest {
+    private static final String TEST_KEYSTORE = "./src/test/resources/keystoretest.jks";
+    private static final char[] TEST_KEYSTORE_PASSWORD = "Notchangeme".toCharArray();
+
     @Test
     public void buildUnsecure() {
         HttpClientBuilder builder = new HttpClientBuilder();
@@ -74,5 +91,75 @@ public class HttpClientBuilderTest {
         HttpClientBuilder builder = new HttpClientBuilder();
         CloseableHttpClient client = builder.build();
         Assert.assertNotNull(client);
+    }
+
+    @Test
+    public void buildKerberosUsesDefaultCertificateValidation() throws Exception {
+        HttpsServer server = startHttpsServer();
+        try (CloseableHttpClient client = createKerberosHecClient(serverUrl(server), false)) {
+            try {
+                client.execute(new HttpGet(serverUrl(server)));
+                Assert.fail("Expected Kerberos client to reject an untrusted HTTPS certificate");
+            } catch (SSLException expected) {
+                Assert.assertNotNull(expected);
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void buildKerberosHonorsDisabledCertificateValidation() throws Exception {
+        HttpsServer server = startHttpsServer();
+        try (CloseableHttpClient client = createKerberosHecClient(serverUrl(server), true);
+             CloseableHttpResponse response = client.execute(new HttpGet(serverUrl(server)))) {
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            EntityUtils.consume(response.getEntity());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static HttpsServer startHttpsServer() throws Exception {
+        HttpsServer server = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(createServerSslContext()));
+        server.createContext("/", exchange -> {
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(response);
+            }
+        });
+        server.start();
+        return server;
+    }
+
+    private static CloseableHttpClient createKerberosHecClient(
+            String uri,
+            boolean disableSslCertVerification
+    ) {
+        HecConfig config = new HecConfig(Collections.singletonList(uri), "token")
+            .setKerberosPrincipal("user@EXAMPLE.COM")
+            .setDisableSSLCertVerification(disableSslCertVerification);
+        return Hec.createHttpClient(config);
+    }
+
+    private static SSLContext createServerSslContext() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        try (FileInputStream inputStream = new FileInputStream(TEST_KEYSTORE)) {
+            keyStore.load(inputStream, TEST_KEYSTORE_PASSWORD);
+        }
+
+        KeyManagerFactory keyManagerFactory =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, TEST_KEYSTORE_PASSWORD);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+        return sslContext;
+    }
+
+    private static String serverUrl(HttpsServer server) {
+        return "https://localhost:" + server.getAddress().getPort();
     }
 }

--- a/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
+++ b/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
@@ -15,55 +15,57 @@
  */
 package com.splunk.hecclient;
 
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
-import java.io.FileInputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyStore;
 import java.util.Collections;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
-public class HttpClientBuilderTest {
-    private static final String TEST_KEYSTORE = "./src/test/resources/keystoretest.jks";
-    private static final char[] TEST_KEYSTORE_PASSWORD = "Notchangeme".toCharArray();
-
+class HttpClientBuilderTest {
     @Test
-    public void buildUnsecure() {
+    void buildUnsecure() {
+        // given
         HttpClientBuilder builder = new HttpClientBuilder();
+
+        // when
         CloseableHttpClient client = builder.setMaxConnectionPoolSizePerDestination(1)
                 .setMaxConnectionPoolSize(2)
                 .setSocketSendBufferSize(1024)
                 .setSocketTimeout(120)
                 .setDisableSSLCertVerification(true)
                 .build();
+
+        // then
         Assert.assertNotNull(client);
     }
 
     @Test
-    public void buildSecureDefault() {
+    void buildSecureDefault() {
+        // given
         HttpClientBuilder builder = new HttpClientBuilder();
+
+        // when
         CloseableHttpClient client = builder.setMaxConnectionPoolSizePerDestination(1)
                 .setMaxConnectionPoolSize(2)
                 .setSocketSendBufferSize(1024)
                 .setSocketTimeout(120)
                 .setDisableSSLCertVerification(false)
                 .build();
+
+        // then
         Assert.assertNotNull(client);
     }
     @Test
-    public void buildSecureCustomKeystore() {
+    void buildSecureCustomKeystore() {
+        // given
         HttpClientBuilder builder = new HttpClientBuilder();
+
+        // when
         CloseableHttpClient client = builder.setMaxConnectionPoolSizePerDestination(1)
                 .setMaxConnectionPoolSize(2)
                 .setSocketSendBufferSize(1024)
@@ -71,11 +73,16 @@ public class HttpClientBuilderTest {
                 .setDisableSSLCertVerification(false)
                 .setSslContext(Hec.loadCustomSSLContext("./src/test/resources/keystoretest.jks", "JKS", "Notchangeme"))
                 .build();
+
+        // then
         Assert.assertNotNull(client);
     }
     @Test
-    public void buildSecureCustomKeystorePkcs12() {
+    void buildSecureCustomKeystorePkcs12() {
+        // given
         HttpClientBuilder builder = new HttpClientBuilder();
+
+        // when
         CloseableHttpClient client = builder.setMaxConnectionPoolSizePerDestination(1)
                 .setMaxConnectionPoolSize(2)
                 .setSocketSendBufferSize(1024)
@@ -83,55 +90,56 @@ public class HttpClientBuilderTest {
                 .setDisableSSLCertVerification(false)
                 .setSslContext(Hec.loadCustomSSLContext("./src/test/resources/keystoretest.p12", "PKCS12", "Notchangeme"))
                 .build();
+
+        // then
         Assert.assertNotNull(client);
     }
 
     @Test
-    public void buildDefault() {
+    void buildDefault() {
+        // given
         HttpClientBuilder builder = new HttpClientBuilder();
+
+        // when
         CloseableHttpClient client = builder.build();
+
+        // then
         Assert.assertNotNull(client);
     }
 
     @Test
-    public void buildKerberosUsesDefaultCertificateValidation() throws Exception {
-        HttpsServer server = startHttpsServer();
-        try (CloseableHttpClient client = createKerberosHecClient(serverUrl(server), false)) {
+    @ExtendWith(HttpsServerExtension.class)
+    void buildKerberosUsesDefaultCertificateValidation(
+            HttpsServerExtension.Server httpsServer
+    ) throws Exception {
+        // given
+        try (CloseableHttpClient client = createKerberosHecClient(httpsServer.url(), false)) {
             try {
-                client.execute(new HttpGet(serverUrl(server)));
+                // when
+                client.execute(new HttpGet(httpsServer.url()));
+
+                // then
                 Assert.fail("Expected Kerberos client to reject an untrusted HTTPS certificate");
             } catch (SSLException expected) {
+                // then
                 Assert.assertNotNull(expected);
             }
-        } finally {
-            server.stop(0);
         }
     }
 
     @Test
-    public void buildKerberosHonorsDisabledCertificateValidation() throws Exception {
-        HttpsServer server = startHttpsServer();
-        try (CloseableHttpClient client = createKerberosHecClient(serverUrl(server), true);
-             CloseableHttpResponse response = client.execute(new HttpGet(serverUrl(server)))) {
+    @ExtendWith(HttpsServerExtension.class)
+    void buildKerberosHonorsDisabledCertificateValidation(
+            HttpsServerExtension.Server httpsServer
+    ) throws Exception {
+        // given
+        // when
+        try (CloseableHttpClient client = createKerberosHecClient(httpsServer.url(), true);
+             CloseableHttpResponse response = client.execute(new HttpGet(httpsServer.url()))) {
+            // then
             Assert.assertEquals(200, response.getStatusLine().getStatusCode());
             EntityUtils.consume(response.getEntity());
-        } finally {
-            server.stop(0);
         }
-    }
-
-    private static HttpsServer startHttpsServer() throws Exception {
-        HttpsServer server = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
-        server.setHttpsConfigurator(new HttpsConfigurator(createServerSslContext()));
-        server.createContext("/", exchange -> {
-            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
-            exchange.sendResponseHeaders(200, response.length);
-            try (OutputStream outputStream = exchange.getResponseBody()) {
-                outputStream.write(response);
-            }
-        });
-        server.start();
-        return server;
     }
 
     private static CloseableHttpClient createKerberosHecClient(
@@ -142,24 +150,5 @@ public class HttpClientBuilderTest {
             .setKerberosPrincipal("user@EXAMPLE.COM")
             .setDisableSSLCertVerification(disableSslCertVerification);
         return Hec.createHttpClient(config);
-    }
-
-    private static SSLContext createServerSslContext() throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JKS");
-        try (FileInputStream inputStream = new FileInputStream(TEST_KEYSTORE)) {
-            keyStore.load(inputStream, TEST_KEYSTORE_PASSWORD);
-        }
-
-        KeyManagerFactory keyManagerFactory =
-            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, TEST_KEYSTORE_PASSWORD);
-
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
-        return sslContext;
-    }
-
-    private static String serverUrl(HttpsServer server) {
-        return "https://localhost:" + server.getAddress().getPort();
     }
 }

--- a/src/test/java/com/splunk/hecclient/HttpsServerExtension.java
+++ b/src/test/java/com/splunk/hecclient/HttpsServerExtension.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.hecclient;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import java.io.FileInputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+class HttpsServerExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+    private static final String TEST_KEYSTORE = "./src/test/resources/keystoretest.jks";
+    private static final char[] TEST_KEYSTORE_PASSWORD = "Notchangeme".toCharArray();
+    private Server server;
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        server = Server.start();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType() == Server.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return server;
+    }
+
+    static class Server {
+        private final HttpsServer server;
+
+        private Server(HttpsServer server) {
+            this.server = server;
+        }
+
+        private static Server start() throws Exception {
+            HttpsServer server = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
+            server.setHttpsConfigurator(new HttpsConfigurator(createServerSslContext()));
+            server.createContext("/", exchange -> {
+                byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream outputStream = exchange.getResponseBody()) {
+                    outputStream.write(response);
+                }
+            });
+            server.start();
+            return new Server(server);
+        }
+
+        String url() {
+            return "https://localhost:" + server.getAddress().getPort();
+        }
+
+        private void stop() {
+            server.stop(0);
+        }
+    }
+
+    private static SSLContext createServerSslContext() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        try (FileInputStream inputStream = new FileInputStream(TEST_KEYSTORE)) {
+            keyStore.load(inputStream, TEST_KEYSTORE_PASSWORD);
+        }
+
+        KeyManagerFactory keyManagerFactory =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, TEST_KEYSTORE_PASSWORD);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+        return sslContext;
+    }
+}


### PR DESCRIPTION
Issue decription: when Kerberos authentication is turned on (kerberos.user.principal is set), the connector builds a separate HTTP client that skips all TLS certificate and hostname validation, ignoring the operator-configured truststore and the splunk.hec.ssl.validate.certs setting.

Fix description: use the same HTTP client when Kerberos is enabled and disabled

The fix was tested via: unit-tests and manual testing