### PR TITLE
fix: DoS vulnerability through unbounded retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Use the below schema to configure Splunk Connect for Kafka
 | `splunk.hec.ssl.trust.store.password` | Password for Java KeyStore. |`""`|
 | `splunk.hec.json.event.formatted` | Set to `true` for events that are already in HEC format. Valid settings are `true` or `false`. |`false`|
 | `splunk.hec.max.outstanding.events` | Maximum amount of un-acknowledged events kept in memory by connector. Will trigger back-pressure event to slow down collection if reached. | `1000000` |
-| `splunk.hec.max.retries` | Amount of times a failed batch will attempt to resend before dropping events completely. Warning: This will result in data loss, default is `-1` which will retry indefinitely  | `-1` |
+| `splunk.hec.max.retries` | Amount of times a failed batch will attempt to resend before dropping events completely. Warning: This will result in data loss after retries are exhausted. Default is `5`. If set to -1, the retries are never stopped. | `5` |
 | `splunk.hec.backoff.threshhold.seconds` | The amount of duration the Indexer object will be stopped after getting error code while posting the data.</br> **NOTE:** <br/>  Other Indexer won't get affected." | `60` |
 | `splunk.hec.lb.poll.interval`  |  Specify this parameter(in seconds) to control the polling interval(increase to do less polling, decrease to do more frequent polling, set `-1` to disable polling) |  `120` |
 | `splunk.hec.enable.compression` | Valid settings are true or false. Used for enable or disable gzip-compression. |`false`|

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Use the below schema to configure Splunk Connect for Kafka
    "splunk.hec.max.http.connection.per.channel": "<max number of http connections per channel>",
    "splunk.hec.total.channels": "<total number of channels>",
    "splunk.hec.max.batch.size": "<max number of kafka records post in one batch>",
+   "splunk.hec.max.response.size.bytes": "<max HTTP response body bytes to read before truncating>",
    "splunk.hec.threads": "<number of threads to use to do HEC post for single task>",
    "splunk.hec.event.timeout": "<timeout in seconds>",
    "splunk.hec.socket.timeout": "<timeout in seconds>",
@@ -170,6 +171,7 @@ Use the below schema to configure Splunk Connect for Kafka
 | `splunk.hec.max.http.connection.per.channel` | Controls how many HTTP connections will be created and cached in the HTTP pool for one HEC channel. |`2`|
 | `splunk.hec.total.channels` | Controls the total channels created to perform HEC event POSTs. See the Load balancer section for more details. |`2`|
 | `splunk.hec.max.batch.size` | Maximum batch size when posting events to Splunk. The size is the actual number of Kafka events, and not byte size. |`500`|
+| `splunk.hec.max.response.size.bytes` | Maximum HTTP response body size, in bytes, read from Splunk HEC before truncating the response for parsing. |`1048576`|
 | `splunk.hec.threads` | Controls how many threads are spawned to do data injection via HEC in a **single** connector task. |`1`|
 | `splunk.hec.socket.timeout` | Internal TCP socket timeout when connecting to Splunk. Value is in seconds. |`60`|
 | `splunk.hec.ssl.trust.store.path` | Location of Java KeyStore. |`""`|

--- a/src/main/java/com/splunk/hecclient/HecConfig.java
+++ b/src/main/java/com/splunk/hecclient/HecConfig.java
@@ -18,6 +18,7 @@ package com.splunk.hecclient;
 import java.util.List;
 
 public final class HecConfig {
+    public static final int DEFAULT_MAX_RESPONSE_SIZE_BYTES = 1024 * 1024;
 
     private List<String> uris;
     private String token;
@@ -41,6 +42,7 @@ public final class HecConfig {
     private String kerberosKeytabPath;
     private int concurrentHecQueueCapacity = 100;
     private Boolean autoExtractTimestamp;
+    private int maxResponseSizeBytes = DEFAULT_MAX_RESPONSE_SIZE_BYTES;
 
     public HecConfig(List<String> uris, String token) {
         this.uris = uris;
@@ -116,6 +118,8 @@ public final class HecConfig {
     public String getTrustStorePassword() { return trustStorePassword; }
 
     public Boolean getAutoExtractTimestamp() { return autoExtractTimestamp; }
+
+    public int getMaxResponseSizeBytes() { return maxResponseSizeBytes; }
 
     public HecConfig setDisableSSLCertVerification(boolean disableVerfication) {
         disableSSLCertVerification = disableVerfication;
@@ -222,6 +226,11 @@ public final class HecConfig {
 
     public HecConfig setAutoExtractTimestamp(Boolean autoExtractTimestamp) {
         this.autoExtractTimestamp = autoExtractTimestamp;
+        return this;
+    }
+
+    public HecConfig setMaxResponseSizeBytes(int maxResponseSizeBytes) {
+        this.maxResponseSizeBytes = maxResponseSizeBytes;
         return this;
     }
 

--- a/src/main/java/com/splunk/hecclient/Indexer.java
+++ b/src/main/java/com/splunk/hecclient/Indexer.java
@@ -300,7 +300,7 @@ final class Indexer implements IndexerInf {
             return "";
         }
 
-        int maxBytes = Math.max(1, hecConfig.getMaxResponseSizeBytes());
+        int maxBytes = hecConfig.getMaxResponseSizeBytes();
         int initialSize = Math.min(RESPONSE_BUFFER_SIZE, maxBytes);
         try (InputStream input = entity.getContent();
              ByteArrayOutputStream output = new ByteArrayOutputStream(initialSize)) {
@@ -308,7 +308,7 @@ final class Indexer implements IndexerInf {
                 return "";
             }
 
-            byte[] buffer = new byte[RESPONSE_BUFFER_SIZE];
+            byte[] buffer = new byte[initialSize];
             int totalBytes = 0;
             int bytesRead;
             while ((bytesRead = input.read(buffer)) != -1) {

--- a/src/main/java/com/splunk/hecclient/Indexer.java
+++ b/src/main/java/com/splunk/hecclient/Indexer.java
@@ -21,8 +21,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.splunk.kafka.connect.VersionUtils;
 import com.sun.security.auth.module.Krb5LoginModule;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
@@ -40,19 +43,16 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 final class Indexer implements IndexerInf {
     private static final Logger log = LoggerFactory.getLogger(Indexer.class);
     private static final ObjectMapper jsonMapper = new ObjectMapper();
+    private static final int RESPONSE_BUFFER_SIZE = 4096;
 
     private HecConfig hecConfig;
 
@@ -240,7 +240,7 @@ final class Indexer implements IndexerInf {
         String respPayload;
         HttpEntity entity = resp.getEntity();
         try {
-            respPayload = EntityUtils.toString(entity, "utf-8");
+            respPayload = readResponsePayload(entity);
         } catch (Exception ex) {
             log.error("failed to process http response", ex);
             throw new HecException("failed to process http response", ex);
@@ -293,6 +293,38 @@ final class Indexer implements IndexerInf {
         clearBackPressure();
 
         return respPayload;
+    }
+
+    private String readResponsePayload(HttpEntity entity) throws IOException {
+        if (entity == null) {
+            return "";
+        }
+
+        int maxBytes = Math.max(1, hecConfig.getMaxResponseSizeBytes());
+        int initialSize = Math.min(RESPONSE_BUFFER_SIZE, maxBytes);
+        try (InputStream input = entity.getContent();
+             ByteArrayOutputStream output = new ByteArrayOutputStream(initialSize)) {
+            if (input == null) {
+                return "";
+            }
+
+            byte[] buffer = new byte[RESPONSE_BUFFER_SIZE];
+            int totalBytes = 0;
+            int bytesRead;
+            while ((bytesRead = input.read(buffer)) != -1) {
+                int remainingBytes = maxBytes - totalBytes;
+                if (bytesRead > remainingBytes) {
+                    output.write(buffer, 0, remainingBytes);
+                    log.warn("truncated HEC response payload after reaching configured max size of {} bytes",
+                             maxBytes);
+                    break;
+                }
+                output.write(buffer, 0, bytesRead);
+                totalBytes += bytesRead;
+            }
+
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
     }
 
     private void logBackPressure() {

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -50,6 +50,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     static final String TOTAL_HEC_CHANNEL_CONF = "splunk.hec.total.channels";
     static final String MAX_HTTP_CONNECTION_PER_CHANNEL_CONF = "splunk.hec.max.http.connection.per.channel";
     static final String MAX_BATCH_SIZE_CONF = "splunk.hec.max.batch.size"; // record count
+    static final String MAX_RESPONSE_SIZE_CONF = "splunk.hec.max.response.size.bytes";
     static final String HTTP_KEEPALIVE_CONF = "splunk.hec.http.keepalive";
     static final String HEC_THREDS_CONF = "splunk.hec.threads";
     static final String SOCKET_TIMEOUT_CONF = "splunk.hec.socket.timeout"; // seconds
@@ -126,6 +127,8 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
             + "when posting events to Splunk.";
     static final String MAX_BATCH_SIZE_DOC = "Maximum batch size when posting events to Splunk. The size is the actual number of "
             + "Kafka events not the byte size. By default, this is set to 100.";
+    static final String MAX_RESPONSE_SIZE_DOC = "Maximum HTTP response body size, in bytes, read from Splunk HEC before "
+            + "truncating the response for parsing. By default, this is set to 1048576.";
     static final String HTTP_KEEPALIVE_DOC = "Valid settings are true or false. Enables or disables HTTP connection "
             + "keep-alive. By default, this is set to true";
     static final String HEC_THREADS_DOC = "Controls how many threads are spawned to do data injection via HEC in a single "
@@ -224,6 +227,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     final int totalHecChannels;
     final int maxHttpConnPerChannel;
     final int maxBatchSize;
+    final int maxResponseSizeBytes;
     final boolean httpKeepAlive;
     final int numberOfThreads;
     final int socketTimeout;
@@ -298,6 +302,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         trackData = getBoolean(TRACK_DATA_CONF);
         useRecordTimestamp = getBoolean(USE_RECORD_TIMESTAMP_CONF);
         maxBatchSize = getInt(MAX_BATCH_SIZE_CONF);
+        maxResponseSizeBytes = getInt(MAX_RESPONSE_SIZE_CONF);
         numberOfThreads = getInt(HEC_THREDS_CONF);
         if (taskConfig.get(LINE_BREAKER_CONF) != null && taskConfig.get(LINE_BREAKER_CONF).length() == 1) {
             lineBreaker = taskConfig.get(LINE_BREAKER_CONF);
@@ -362,6 +367,8 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(MAX_RETRIES_CONF, ConfigDef.Type.INT, 5, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
                 .define(HEC_BACKOFF_PRESSURE_THRESHOLD, ConfigDef.Type.INT, 60, ConfigDef.Importance.MEDIUM, HEC_BACKOFF_PRESSURE_THRESHOLD_DOC)
                 .define(HEC_EVENT_FORMATTED_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, HEC_EVENT_FORMATTED_DOC)
+                .define(MAX_RESPONSE_SIZE_CONF, ConfigDef.Type.INT, HecConfig.DEFAULT_MAX_RESPONSE_SIZE_BYTES,
+                        ConfigDef.Range.atLeast(1), ConfigDef.Importance.LOW, MAX_RESPONSE_SIZE_DOC)
                 .define(MAX_BATCH_SIZE_CONF, ConfigDef.Type.INT, 500, ConfigDef.Importance.MEDIUM, MAX_BATCH_SIZE_DOC)
                 .define(HEADER_SUPPORT_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, HEADER_SUPPORT_DOC)
                 .define(HEADER_CUSTOM_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, HEADER_CUSTOM_DOC)
@@ -403,6 +410,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
               .setHasCustomTrustStore(hasTrustStorePath)
               .setKerberosPrincipal(kerberosUserPrincipal)
               .setKerberosKeytabPath(kerberosKeytabPath)
+              .setMaxResponseSizeBytes(maxResponseSizeBytes)
               .setConcurrentHecQueueCapacity(queueCapacity)
               .setAutoExtractTimestamp(autoExtractTimestamp);
         return config;
@@ -436,6 +444,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 + "totalHecChannels:" + totalHecChannels + ", "
                 + "enrichment:" + getString(ENRICHMENT_CONF) + ", "
                 + "maxBatchSize:" + maxBatchSize + ", "
+                + "maxResponseSizeBytes:" + maxResponseSizeBytes + ", "
                 + "numberOfThreads:" + numberOfThreads + ", "
                 + "lineBreaker:" + lineBreaker + ", "
                 + "maxOutstandingEvents:" + maxOutstandingEvents + ", "

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -156,7 +156,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
             + "Will trigger back-pressure event to slow collection. By default, this "
             + "is set to 1000000.";
     static final String MAX_RETRIES_DOC = "Number of retries for failed batches before giving up. By default this is set to "
-            + "-1 which will retry indefinitely.";
+            + "5. If set to -1, the retries are never stopped.";
 
     static final String HEC_BACKOFF_PRESSURE_THRESHOLD_DOC = "The amount of time Splunk Connect for Kafka waits on errors "
             + "sending events to Splunk to attempt resending it";
@@ -359,7 +359,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(HEC_THREDS_CONF, ConfigDef.Type.INT, 1, ConfigDef.Importance.LOW, HEC_THREADS_DOC)
                 .define(LINE_BREAKER_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, LINE_BREAKER_DOC)
                 .define(MAX_OUTSTANDING_EVENTS_CONF, ConfigDef.Type.INT, 1000000, ConfigDef.Importance.MEDIUM, MAX_OUTSTANDING_EVENTS_DOC)
-                .define(MAX_RETRIES_CONF, ConfigDef.Type.INT, -1, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
+                .define(MAX_RETRIES_CONF, ConfigDef.Type.INT, 5, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
                 .define(HEC_BACKOFF_PRESSURE_THRESHOLD, ConfigDef.Type.INT, 60, ConfigDef.Importance.MEDIUM, HEC_BACKOFF_PRESSURE_THRESHOLD_DOC)
                 .define(HEC_EVENT_FORMATTED_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, HEC_EVENT_FORMATTED_DOC)
                 .define(MAX_BATCH_SIZE_CONF, ConfigDef.Type.INT, 500, ConfigDef.Importance.MEDIUM, MAX_BATCH_SIZE_DOC)

--- a/src/test/java/com/splunk/hecclient/HecConfigTest.java
+++ b/src/test/java/com/splunk/hecclient/HecConfigTest.java
@@ -48,6 +48,7 @@ public class HecConfigTest {
               .setTrustStorePassword("pass")
               .setHasCustomTrustStore(true)
               .setBackoffThresholdSeconds(10)
+              .setMaxResponseSizeBytes(11)
               .setlbPollInterval(120);
 
         Assert.assertTrue(config.getDisableSSLCertVerification());
@@ -65,6 +66,7 @@ public class HecConfigTest {
         Assert.assertEquals("pass", config.getTrustStorePassword());
         Assert.assertEquals(10000, config.getBackoffThresholdSeconds());
         Assert.assertEquals(120000, config.getlbPollInterval());
+        Assert.assertEquals(11, config.getMaxResponseSizeBytes());
         Assert.assertTrue(config.getHasCustomTrustStore());
     }
 }

--- a/src/test/java/com/splunk/hecclient/IndexerTest.java
+++ b/src/test/java/com/splunk/hecclient/IndexerTest.java
@@ -18,6 +18,7 @@ package com.splunk.hecclient;
 import com.splunk.kafka.connect.VersionUtils;
 import java.util.Collections;
 import org.apache.http.Header;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
@@ -183,6 +184,19 @@ public class IndexerTest {
         client.setResponse(CloseableHttpClientMock.SUCCESS);
         client.setThrowOnGetContent(true);
         assertFailure(client);
+    }
+
+    @Test
+    public void executeHttpRequestTruncatesOversizedResponse() {
+        CloseableHttpClientMock client = new CloseableHttpClientMock();
+        client.setResponse(CloseableHttpClientMock.SUCCESS);
+        HecConfig config = new HecConfig(Collections.emptyList(), token)
+            .setKerberosPrincipal("")
+            .setMaxResponseSizeBytes(8);
+
+        Indexer indexer = new Indexer(baseUrl, client, new PollerMock(), config);
+
+        Assert.assertEquals("{\"text\":", indexer.executeHttpRequest(new HttpPost(baseUrl)));
     }
 
     private Indexer assertFailure(CloseableHttpClient client) {

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -48,6 +48,17 @@ public class SplunkSinkConnectorConfigTest {
     }
 
     @Test
+    public void defaultsMaxRetriesToFive() {
+        UnitUtil uu = new UnitUtil(0);
+        Map<String, String> config = uu.createTaskConfig();
+        config.remove(SplunkSinkConnectorConfig.MAX_RETRIES_CONF);
+
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
+
+        Assert.assertEquals(5, connectorConfig.maxRetries);
+    }
+
+    @Test
     public void getHecConfig() {
         for (int i = 0; i < 2; i++) {
             UnitUtil uu = new UnitUtil(0);

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -82,7 +82,21 @@ public class SplunkSinkConnectorConfigTest {
             Assert.assertEquals(uu.configProfile.getAckPollInterval(), config.getAckPollInterval());
             Assert.assertEquals(uu.configProfile.getAckPollThreads(), config.getAckPollThreads());
             Assert.assertEquals(uu.configProfile.isTrackData(), config.getEnableChannelTracking());
+            Assert.assertEquals(HecConfig.DEFAULT_MAX_RESPONSE_SIZE_BYTES, config.getMaxResponseSizeBytes());
         }
+    }
+
+    @Test
+    public void getHecConfigCustomMaxResponseSize() {
+        UnitUtil uu = new UnitUtil(0);
+        Map<String, String> taskConfig = uu.createTaskConfig();
+        taskConfig.put(SplunkSinkConnectorConfig.MAX_RESPONSE_SIZE_CONF, "2048");
+
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(taskConfig);
+        HecConfig config = connectorConfig.getHecConfig();
+
+        Assert.assertEquals(2048, connectorConfig.maxResponseSizeBytes);
+        Assert.assertEquals(2048, config.getMaxResponseSizeBytes());
     }
 
     @Test
@@ -338,6 +352,7 @@ public class SplunkSinkConnectorConfigTest {
         Assert.assertEquals(uu.configProfile.getSocketTimeout(), connectorConfig.socketTimeout);
         Assert.assertEquals(uu.configProfile.isTrackData(), connectorConfig.trackData);
         Assert.assertEquals(uu.configProfile.getMaxBatchSize(), connectorConfig.maxBatchSize);
+        Assert.assertEquals(HecConfig.DEFAULT_MAX_RESPONSE_SIZE_BYTES, connectorConfig.maxResponseSizeBytes);
         Assert.assertEquals(uu.configProfile.getNumOfThreads(), connectorConfig.numberOfThreads);
     }
 }


### PR DESCRIPTION
Jira Issue - https://splunk.atlassian.net/browse/VULN-83425

- updated the default value to 5 for `splunk.hec.max.retries` to avoid retries indefinitely
- cap HEC response-body reads with a configurable `splunk.hec.max.response.size.bytes` limit to prevent unbounded retry/memory exposure.