### PR TITLE
fix: DoS vulnerability through unbounded retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Use the below schema to configure Splunk Connect for Kafka
 | `splunk.hec.ssl.trust.store.password` | Password for Java KeyStore. |`""`|
 | `splunk.hec.json.event.formatted` | Set to `true` for events that are already in HEC format. Valid settings are `true` or `false`. |`false`|
 | `splunk.hec.max.outstanding.events` | Maximum amount of un-acknowledged events kept in memory by connector. Will trigger back-pressure event to slow down collection if reached. | `1000000` |
-| `splunk.hec.max.retries` | Amount of times a failed batch will attempt to resend before dropping events completely. Warning: This will result in data loss, default is `-1` which will retry indefinitely  | `-1` |
+| `splunk.hec.max.retries` | Amount of times a failed batch will attempt to resend before dropping events completely. Warning: This will result in data loss after retries are exhausted. Default is `5`. If set to -1, the retries are never stopped. | `5` |
 | `splunk.hec.backoff.threshhold.seconds` | The amount of duration the Indexer object will be stopped after getting error code while posting the data.</br> **NOTE:** <br/>  Other Indexer won't get affected." | `60` |
 | `splunk.hec.lb.poll.interval`  |  Specify this parameter(in seconds) to control the polling interval(increase to do less polling, decrease to do more frequent polling, set `-1` to disable polling) |  `120` |
 | `splunk.hec.enable.compression` | Valid settings are true or false. Used for enable or disable gzip-compression. |`false`|

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -156,7 +156,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
             + "Will trigger back-pressure event to slow collection. By default, this "
             + "is set to 1000000.";
     static final String MAX_RETRIES_DOC = "Number of retries for failed batches before giving up. By default this is set to "
-            + "-1 which will retry indefinitely.";
+            + "5. If set to -1, the retries are never stopped.";
 
     static final String HEC_BACKOFF_PRESSURE_THRESHOLD_DOC = "The amount of time Splunk Connect for Kafka waits on errors "
             + "sending events to Splunk to attempt resending it";
@@ -359,7 +359,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(HEC_THREDS_CONF, ConfigDef.Type.INT, 1, ConfigDef.Importance.LOW, HEC_THREADS_DOC)
                 .define(LINE_BREAKER_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, LINE_BREAKER_DOC)
                 .define(MAX_OUTSTANDING_EVENTS_CONF, ConfigDef.Type.INT, 1000000, ConfigDef.Importance.MEDIUM, MAX_OUTSTANDING_EVENTS_DOC)
-                .define(MAX_RETRIES_CONF, ConfigDef.Type.INT, -1, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
+                .define(MAX_RETRIES_CONF, ConfigDef.Type.INT, 5, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
                 .define(HEC_BACKOFF_PRESSURE_THRESHOLD, ConfigDef.Type.INT, 60, ConfigDef.Importance.MEDIUM, HEC_BACKOFF_PRESSURE_THRESHOLD_DOC)
                 .define(HEC_EVENT_FORMATTED_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, HEC_EVENT_FORMATTED_DOC)
                 .define(MAX_BATCH_SIZE_CONF, ConfigDef.Type.INT, 500, ConfigDef.Importance.MEDIUM, MAX_BATCH_SIZE_DOC)

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -48,6 +48,17 @@ public class SplunkSinkConnectorConfigTest {
     }
 
     @Test
+    public void defaultsMaxRetriesToFive() {
+        UnitUtil uu = new UnitUtil(0);
+        Map<String, String> config = uu.createTaskConfig();
+        config.remove(SplunkSinkConnectorConfig.MAX_RETRIES_CONF);
+
+        SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(config);
+
+        Assert.assertEquals(5, connectorConfig.maxRetries);
+    }
+
+    @Test
     public void getHecConfig() {
         for (int i = 0; i < 2; i++) {
             UnitUtil uu = new UnitUtil(0);


### PR DESCRIPTION
Jira Issue - https://splunk.atlassian.net/browse/VULN-83425

- updated the default value to 5 for splunk.hec.max.retries to avoid retries indefinitely
