### PR TITLE
feat: add Kafka 4.x KRaft support & update GitHub Actions

### DIFF
--- a/.github/workflows/ci_build_test.yaml
+++ b/.github/workflows/ci_build_test.yaml
@@ -43,7 +43,7 @@ jobs:
       - workflow_approval
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -55,7 +55,7 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       - name: upload THIRDPARTY file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: THIRDPARTY
           path: /tmp/THIRDPARTY
@@ -79,7 +79,7 @@ jobs:
       image: returntocorp/semgrep
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -130,10 +130,16 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '17'
 
       - name: Get maven dependencies
         run: |
@@ -145,13 +151,13 @@ jobs:
           cp -R target/splunk-kafka-connect*.jar /tmp
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: splunk-kafka-connector
           path: /tmp/splunk-kafka-connect*.jar
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: >-
           always() &&
           (github.event_name != 'pull_request' ||
@@ -179,22 +185,33 @@ jobs:
             kafka_package: "kafka_2.12-3.5.1.tgz"
             confluent_major_version: "7.5"
             confluent_package_version: "7.5.9"
+            kraft: false
           - kafka_version: "3.6.2"
             kafka_package: "kafka_2.12-3.6.2.tgz"
             confluent_major_version: "7.6"
             confluent_package_version: "7.6.6"
+            kraft: false
           - kafka_version: "3.7.2"
             kafka_package: "kafka_2.12-3.7.2.tgz"
             confluent_major_version: "7.7"
             confluent_package_version: "7.7.4"
+            kraft: false
           - kafka_version: "3.8.1"
             kafka_package: "kafka_2.12-3.8.1.tgz"
             confluent_major_version: "7.8"
             confluent_package_version: "7.8.3"
+            kraft: false
           - kafka_version: "3.9.0"
             kafka_package: "kafka_2.12-3.9.0.tgz"
             confluent_major_version: "7.9"
             confluent_package_version: "7.9.2"
+            kraft: false
+          - kafka_version: "4.3.1"
+            kafka_package: "kafka_2.13-4.3.1.tgz"
+            confluent_major_version: "8.3"
+            confluent_package_version: "8.3.0"
+            kraft: true
+
     env:
       CI_SPLUNK_VERSION: ${{matrix.splunk.splunk_version}}
       CI_SPLUNK_FILENAME: ${{matrix.splunk.splunk_filename}}
@@ -212,10 +229,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '17'
 
       - name: Install Splunk
         run: |
@@ -260,24 +283,33 @@ jobs:
           cd /usr/local/kafka && ls
 
       - name: Start ZooKeeper Server
+        if: ${{ !matrix.kafka.kraft }}
         working-directory: /usr/local/kafka
         run: |
           echo "Start ZooKeeper"
           sudo bin/zookeeper-server-start.sh config/zookeeper.properties &
 
-      - name: Start Kafka Server
+      - name: Start Kafka Server (ZooKeeper mode)
+        if: ${{ !matrix.kafka.kraft }}
         working-directory: /usr/local/kafka
         run: |
-          echo "Start kafka server"
           sudo bin/kafka-server-start.sh config/server.properties &
 
-      - uses: actions/setup-python@v4
+      - name: Start Kafka Server (KRaft mode)
+        if: ${{ matrix.kafka.kraft }}
+        working-directory: /usr/local/kafka
+        run: |
+          KAFKA_CLUSTER_ID=$(bin/kafka-storage.sh random-uuid)
+          bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
+          sudo bin/kafka-server-start.sh config/server.properties &
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.11
           check-latest: true
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: splunk-kafka-connector
           path: /tmp
@@ -398,7 +430,7 @@ jobs:
           python test/lib/eventproducer_connector_upgrade.py 2000 --log-level=INFO
           # Check in splunk that we have recieved 2000 events for with ack and without ack tasks
           python test/lib/connector_upgrade.py --log-level=INFO
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: kafka-connect-logs-${{ matrix.kafka.kafka_version }}
@@ -420,7 +452,7 @@ jobs:
           echo "Running functional tests....."
           python -m pytest --log-level=INFO
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: splunk-events-${{ matrix.kafka.kafka_version }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Splunk Connect for Kafka is a Kafka Connect Sink for Splunk with the following f
 
 ## Requirements
 1. Kafka version 1.0.0 and above. 
-   * Tested with following versions: 1.1.1, 2.0.0, 2.1.0, 2.6.0, 2.7.1, 2.8.0, 3.0.0, 3.1.0, 3.3.1, 3.4.1, 3.5.1
+   * Tested with following versions: 1.1.1, 2.0.0, 2.1.0, 2.6.0, 2.7.1, 2.8.0, 3.0.0, 3.1.0, 3.3.1, 3.4.1, 3.5.1, 3.6.2, 3.7.2, 3.8.1, 3.9.0, 4.3.1
 2. Java 8 and above.
 3. A Splunk environment of version 8.0.0 and above, configured with valid HTTP Event Collector (HEC) tokens.
 
@@ -27,7 +27,7 @@ Splunk Connect for Kafka lets you subscribe to a Kafka topic and stream the data
 ## Build
 
 1. Clone the repo from https://github.com/splunk/kafka-connect-splunk
-2. Verify that Java8 JRE or JDK is installed.
+2. Verify that Java 8 JRE or JDK is installed.
 3. Verify that maven is installed.
 4. Run `mvn package`. This will build the jar in the /target directory. The name will be `splunk-kafka-connect-[VERSION].jar`.
 

--- a/ci/run_kafka_connect.sh
+++ b/ci/run_kafka_connect.sh
@@ -22,11 +22,17 @@ sed -i 's/value.converter=org.apache.kafka.connect.storage.StringConverter/value
 
 cd kafka
 
-echo "Start ZooKeeper"
-bin/zookeeper-server-start.sh config/zookeeper.properties > /kafka-connect/logs/zookeeper.txt 2>&1 &
-
-echo "Start kafka server"
-bin/kafka-server-start.sh config/server.properties > /kafka-connect/logs/kafka.txt 2>&1 &
+if [ -f bin/zookeeper-server-start.sh ]; then
+  echo "Start ZooKeeper"
+  bin/zookeeper-server-start.sh config/zookeeper.properties > /kafka-connect/logs/zookeeper.txt 2>&1 &
+  echo "Start kafka server (ZooKeeper mode)"
+  bin/kafka-server-start.sh config/server.properties > /kafka-connect/logs/kafka.txt 2>&1 &
+else
+  echo "Start Kafka (KRaft mode - Kafka 4.x+)"
+  KAFKA_CLUSTER_ID=$(bin/kafka-storage.sh random-uuid)
+  bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
+  bin/kafka-server-start.sh config/server.properties > /kafka-connect/logs/kafka.txt 2>&1 &
+fi
 
 echo "Run connect"
 ./bin/connect-distributed.sh /kafka-connect/kafka-connect-splunk/config/connect-distributed-quickstart.properties > /kafka-connect/logs/kafka_connect.txt 2>&1 &

--- a/config/connect-distributed-quickstart.properties
+++ b/config/connect-distributed-quickstart.properties
@@ -12,14 +12,6 @@ value.converter=org.apache.kafka.connect.storage.StringConverter
 key.converter.schemas.enable=false
 value.converter.schemas.enable=false
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Copcyat in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 # Flush much faster (10s) than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000
 

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -12,14 +12,6 @@ value.converter=org.apache.kafka.connect.storage.StringConverter
 key.converter.schemas.enable=false
 value.converter.schemas.enable=false
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Copcyat in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 # Flush much faster (10s) than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <junit.vintage.version>5.9.2</junit.vintage.version>
         <junit.platform.version>1.9.2</junit.platform.version>
         <jackson.version>2.22.1</jackson.version>
-        <kafka.version>3.9.2</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <slf4j.version>2.0.7</slf4j.version>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/test/lib/eventproducer_connector_upgrade.py
+++ b/test/lib/eventproducer_connector_upgrade.py
@@ -33,11 +33,13 @@ def check_events_from_topic(target):
         kafka_version_flag = os.environ.get("CI_KAFKA_VERSION_BEFORE_3_7")
         if kafka_version_flag == "true":
             class_name = "kafka.tools.GetOffsetShell"
+            broker_option = "--broker-list"
         else:
             class_name = "org.apache.kafka.tools.GetOffsetShell"
-        output1 = subprocess.getoutput(f"echo $(/usr/local/kafka/bin/kafka-run-class.sh {class_name} --broker-list 'localhost:9092' --topic kafka_connect_upgrade  --time -1 2>/dev/null"
+            broker_option = "--bootstrap-server"
+        output1 = subprocess.getoutput(f"echo $(/usr/local/kafka/bin/kafka-run-class.sh {class_name} {broker_option} 'localhost:9092' --topic kafka_connect_upgrade  --time -1 2>/dev/null"
                                        + " | grep -e ':[[:digit:]]*:' | grep -v WARN | awk -F  ':' '{sum += $3} END {print sum}')")
-        output2 = subprocess.getoutput(f"echo $(/usr/local/kafka/bin/kafka-run-class.sh {class_name} --broker-list 'localhost:9092' --topic kafka_connect_upgrade --time -2 2>/dev/null"
+        output2 = subprocess.getoutput(f"echo $(/usr/local/kafka/bin/kafka-run-class.sh {class_name} {broker_option} 'localhost:9092' --topic kafka_connect_upgrade --time -2 2>/dev/null"
                                        + " | grep -e ':[[:digit:]]*:' | grep -v WARN | awk -F  ':' '{sum += $3} END {print sum}')")
         time.sleep(5)
         if (int(output1)-int(output2))==target:


### PR DESCRIPTION
- Extend CI matrix with Kafka 4.3.1 (KRaft) alongside existing 3.5.1-3.9.0 (ZooKeeper)
- Add Java 17 Temurin to build and e2e jobs
- Remove internal.key/value.converter from Connect configs
- Auto-detect ZooKeeper vs KRaft in ci/run_kafka_connect.sh
- Use version-compatible GetOffsetShell options in upgrade tests
- Update kafka.version to 4.3.1
- Update README tested-versions list
- Pin all GitHub Actions to full commit SHA