### PR TITLE
feat: add timeout to regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Use the below schema to configure Splunk Connect for Kafka
 |--------           |----------------------------|-----------------------|
 | `enable.timestamp.extraction` |  To enable timestamp extraction ,set the value of this field to `true`. <br/> **NOTE:** <br/> Applicable only if `splunk.hec.raw` is `false` | `false` |
 | `timestamp.regex` |  Regex for timestamp extraction. <br/> **NOTE:** <br/> Regex must have name captured group `"time"` For eg.: `\\\"time\\\":\\s*\\\"(?<time>.*?)\"` | `""` |
+| `timestamp.regex.timeout.ms` | Maximum time in milliseconds for one timestamp regex evaluation. Must be a positive integer. When the timeout is reached, timestamp extraction is skipped for that event and the connector logs a warning. | `500` |
 | `timestamp.format` |  Time-format for timestamp extraction .<br/>For eg.: <br/>If timestamp is `1555209605000` , set `timestamp.format` to `"epoch"` format.<br/> If timestamp is `Jun 13 2010 23:11:52.454 UTC` , set `timestamp.format` to `"MMM dd yyyy HH:mm:ss.SSS zzz".`. <br/> If timestamp is in ISO8601 format `2022-03-29'T'23:11:52.054` , set `timestamp.format` to `"yyyy-MM-dd'\''T'\''HH:mm:ss.SSS"` | `""` |
 | `timestamp.timezone` | Timezone used for extracted timestamp. Defaults to local timezone if nothing is specified | `""` |
 
@@ -257,7 +258,6 @@ Use the below schema to configure Splunk Connect for Kafka
 |--------               |----------------------------|
 | `Out of  band health check` |  This health check targets Loadbalancer and aims to remove all the unhealthy channels from the pool; all unhealthy channels are released for the configurable period using the parameter `splunk.hec.lb.poll.interval`, Although this is configurable (by default 120 seconds), It may still get a 503 result code from the Splunk indexer. For that, there is another health check, and it can be called the in-band-health check. | 
 | `In band healthcheck` | This health check targets Indexer object while posting data. If an error code is received, then it will trigger this health check. When this check fails, It will Pause the indexing from the Particular Indexer object for a configurable time using the parameter `Splunk.hec.backoff.threshhold.seconds` and trigger backpressure handling So that event that could not be indexed will be retried again.  | 
-
 
 ## Load balancing
 

--- a/src/main/java/com/splunk/kafka/connect/RegexTimeoutException.java
+++ b/src/main/java/com/splunk/kafka/connect/RegexTimeoutException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.kafka.connect;
+
+public class RegexTimeoutException extends RuntimeException {
+    public RegexTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Splunk, Inc..
+ * Copyright 2026 Splunk, Inc..
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
      // Input the Regex String and timestamp format
      static final String ENABLE_TIMESTAMP_EXTRACTION_CONF = "enable.timestamp.extraction";
      static final String REGEX_CONF = "timestamp.regex";
+     static final String REGEX_TIMEOUT_MS_CONF = "timestamp.regex.timeout.ms";
      static final String TIMESTAMP_FORMAT_CONF = "timestamp.format";
      static final String TIMESTAMP_TIMEZONE_CONF = "timestamp.timezone";
 
@@ -213,6 +214,8 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
 
     static final String ENABLE_TIMESTAMP_EXTRACTION_DOC = "Set to true if you want to extract the timestamp";
     static final String REGEX_DOC = "Regex";
+    static final String REGEX_TIMEOUT_MS_DOC = "Maximum time in milliseconds allowed for a timestamp regex evaluation. "
+            + "The connector skips timestamp extraction when this timeout is reached. Default is 500 milliseconds.";
     static final String TIMESTAMP_FORMAT_DOC = "Timestamp format";
     static final String TIMESTAMP_TIMEZONE_DOC = "Timestamp timezone";
 
@@ -270,6 +273,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
 
     final boolean enableTimestampExtraction;
     final String regex;
+    final int regexTimeoutMs;
     final String timestampFormat;
     final int queueCapacity;
     final String timeZone;
@@ -328,6 +332,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         disableValidation = getBoolean(DISABLE_VALIDATION);
         enableTimestampExtraction = getBoolean(ENABLE_TIMESTAMP_EXTRACTION_CONF);
         regex = getString(REGEX_CONF);
+        regexTimeoutMs = getInt(REGEX_TIMEOUT_MS_CONF);
         timestampFormat = getString(TIMESTAMP_FORMAT_CONF).trim();
         timeZone = getString(TIMESTAMP_TIMEZONE_CONF);
         validateRegexForTimestamp(regex);
@@ -336,7 +341,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         autoExtractTimestamp = getBoolean(AUTO_EXTRACT_TIMESTAMP_CONF);
     }
 
-   
+
     public static ConfigDef conf() {
         return new ConfigDef()
                 .define(TOKEN_CONF, ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, TOKEN_DOC)
@@ -383,6 +388,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(KERBEROS_KEYTAB_PATH_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, KERBEROS_KEYTAB_LOCATION_DOC)
                 .define(ENABLE_TIMESTAMP_EXTRACTION_CONF, ConfigDef.Type.BOOLEAN,  false , ConfigDef.Importance.MEDIUM, ENABLE_TIMESTAMP_EXTRACTION_DOC)
                 .define(REGEX_CONF, ConfigDef.Type.STRING,  "" , ConfigDef.Importance.MEDIUM, REGEX_DOC)
+                .define(REGEX_TIMEOUT_MS_CONF, ConfigDef.Type.INT, 500, ConfigDef.Range.atLeast(1), ConfigDef.Importance.MEDIUM, REGEX_TIMEOUT_MS_DOC)
                 .define(TIMESTAMP_FORMAT_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, TIMESTAMP_FORMAT_DOC)
                 .define(TIMESTAMP_TIMEZONE_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, TIMESTAMP_TIMEZONE_DOC)
                 .define(QUEUE_CAPACITY_CONF, ConfigDef.Type.INT, 100, ConfigDef.Importance.LOW, QUEUE_CAPACITY_DOC);

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Splunk, Inc..
+ * Copyright 2026 Splunk, Inc..
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -546,7 +546,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         String string = jsonStr.replaceAll("\\\"", "\"");
         String timestamp = "";
         final Pattern pattern = Pattern.compile(connectorConfig.regex);
-        final Matcher matcher = pattern.matcher(string);
+        final Matcher matcher = pattern.matcher(new TimeoutCharSequence(string, connectorConfig.regexTimeoutMs));
         try {
             if (matcher.find()) {
                 timestamp = (matcher.group("time"));

--- a/src/main/java/com/splunk/kafka/connect/TimeoutCharSequence.java
+++ b/src/main/java/com/splunk/kafka/connect/TimeoutCharSequence.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.kafka.connect;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutCharSequence implements CharSequence {
+
+    private final CharSequence input;
+    private final long startNanos;
+    private final long timeoutNanos;
+    private long noCalls;
+    private static final long TIMEOUT_CHECK_INTERVAL = 1_000_000;
+
+    public TimeoutCharSequence(CharSequence input, long timeoutMillis) {
+        this(input, System.nanoTime(), TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
+    }
+
+    public TimeoutCharSequence(CharSequence input, long startNanos, long timeoutNanos) {
+        this.input = input;
+        this.startNanos = startNanos;
+        this.timeoutNanos = timeoutNanos;
+        this.noCalls = 0;
+    }
+
+    @Override
+    public int length() {
+        return input.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        this.noCalls += 1;
+        if (this.noCalls % TIMEOUT_CHECK_INTERVAL == 0) {
+            checkTimeout();
+        }
+        return input.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return new TimeoutCharSequence(input.subSequence(start, end), startNanos, timeoutNanos);
+    }
+
+    @Override
+    public String toString() {
+        return input.toString();
+    }
+
+    private void checkTimeout() {
+        if (System.nanoTime() - startNanos > timeoutNanos) {
+            throw new RegexTimeoutException("Timeout");
+        }
+    }
+}

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Splunk, Inc..
+ * Copyright 2026 Splunk, Inc..
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -318,6 +318,39 @@ public class SplunkSinkConnectorConfigTest {
         Assert.assertNotNull(s);
         Assert.assertFalse(s.contains(uu.configProfile.getTrustStorePassword()));
         Assert.assertFalse(s.contains(uu.configProfile.getToken()));
+    }
+
+    @Test
+    public void defaultsRegexTimeoutToFiveHundredMilliseconds() {
+        SplunkSinkConnectorConfig config = new SplunkSinkConnectorConfig(new UnitUtil(0).createTaskConfig());
+
+        Assert.assertEquals(500, config.regexTimeoutMs);
+    }
+
+    @Test
+    public void usesConfiguredRegexTimeout() {
+        Map<String, String> values = new UnitUtil(0).createTaskConfig();
+        values.put(SplunkSinkConnectorConfig.REGEX_TIMEOUT_MS_CONF, "1250");
+
+        SplunkSinkConnectorConfig config = new SplunkSinkConnectorConfig(values);
+
+        Assert.assertEquals(1250, config.regexTimeoutMs);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void rejectsZeroRegexTimeout() {
+        Map<String, String> values = new UnitUtil(0).createTaskConfig();
+        values.put(SplunkSinkConnectorConfig.REGEX_TIMEOUT_MS_CONF, "0");
+
+        new SplunkSinkConnectorConfig(values);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void rejectsNegativeRegexTimeout() {
+        Map<String, String> values = new UnitUtil(0).createTaskConfig();
+        values.put(SplunkSinkConnectorConfig.REGEX_TIMEOUT_MS_CONF, "-1");
+
+        new SplunkSinkConnectorConfig(values);
     }
 
     private void assertMeta(final SplunkSinkConnectorConfig connectorConfig) {

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Splunk, Inc..
+ * Copyright 2026 Splunk, Inc..
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -321,6 +321,7 @@ public class SplunkSinkTaskTest {
         config.put(SplunkSinkConnectorConfig.RAW_CONF, String.valueOf(false));
         config.put(SplunkSinkConnectorConfig.ENABLE_TIMESTAMP_EXTRACTION_CONF, String.valueOf(true));
         config.put(SplunkSinkConnectorConfig.REGEX_CONF, "\\\"time\\\":\\s*\\\"(?<time>.*?)\"");
+        config.put(SplunkSinkConnectorConfig.REGEX_TIMEOUT_MS_CONF, "750");
         config.put(SplunkSinkConnectorConfig.TIMESTAMP_FORMAT_CONF, "MMM dd yyyy HH:mm:ss.SSS zzz");
         config.put(SplunkSinkConnectorConfig.TIMESTAMP_TIMEZONE_CONF, "UTC");
 

--- a/src/test/java/com/splunk/kafka/connect/TimeoutCharSequenceTest.java
+++ b/src/test/java/com/splunk/kafka/connect/TimeoutCharSequenceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Splunk, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.kafka.connect;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutCharSequenceTest {
+    @Test
+    public void doesNotTimeoutBeforeMillisecondsDeadline() {
+        TimeoutCharSequence sequence = new TimeoutCharSequence("a", 500);
+
+        for (int i = 0; i < 1_000_000; i++) {
+            Assert.assertEquals('a', sequence.charAt(0));
+        }
+    }
+
+    @Test(expected = RegexTimeoutException.class)
+    public void throwsWhenDeadlineHasElapsedAtTheCheckInterval() {
+        TimeoutCharSequence sequence = new TimeoutCharSequence(
+                "a", System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(501), TimeUnit.MILLISECONDS.toNanos(500));
+
+        for (int i = 0; i < 1_000_000; i++) {
+            sequence.charAt(0);
+        }
+    }
+}


### PR DESCRIPTION
Add timeout to the regex extraction of time to protect against malicious regex patterns.

Issue decription: It was possible to setup a malicious regex pattern that could be used to perform ReDoS/

Fix description: Add an implementation of CharSequence interface to java that checks the timeout (by default 500ms) every one milion iterations of getCharAt() to ensure minimal impact of performance. The value of one milion was choosen experimentally.

The fix was tested via: unit-tests and manual testing.