### PR TITLE
Chore/update wire version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
             <artifactId>kafka-connect-protobuf-converter</artifactId>
             <version>7.1.1</version>
         </dependency>
+        <!-- Override the vulnerable transitive wire-runtime-jvm brought by the Confluent protobuf provider. -->
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-runtime-jvm</artifactId>
+            <version>6.3.0</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -197,11 +197,11 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib -->
+        <!-- Align Kotlin with wire-runtime-jvm 6.3.0. -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.7.0</version>
+            <version>2.0.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency>
@@ -239,11 +239,11 @@
             <artifactId>commons-compress</artifactId>
             <version>1.26.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.squareup.okio/okio-jvm -->
+        <!-- Align Okio with wire-runtime-jvm 6.3.0. -->
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>3.4.0</version>
+            <version>3.17.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,13 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-protobuf-converter</artifactId>
             <version>7.1.1</version>
+            <exclusions>
+                <!-- Replace Confluent's transitive Wire runtime explicitly below. -->
+                <exclusion>
+                    <groupId>com.squareup.wire</groupId>
+                    <artifactId>wire-runtime-jvm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Override the vulnerable transitive wire-runtime-jvm brought by the Confluent protobuf provider. -->
         <dependency>


### PR DESCRIPTION
Issue decription: Vulnerability against CVE-2026-45799.

Fix description: updated wire-runtime-jvm to 6.3.0 together with okio-jvm to 3.17.0 and kotlin-stdlib to 2.0.21

The fix was tested via: unit-tests and manual testing.