### PR TITLE
Bump at.yawk.lz4:lz4-java 1.10.1 -> 1.11.1 (CVE-2026-59949)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <scope>compile</scope>
             <exclusions>
                 <!-- Exclude vulnerable org.lz4:lz4-java (CVE-2025-12183, CVE-2025-66566);
-                     replaced below with the patched fork at.yawk.lz4:lz4-java:1.10.1 -->
+                     replaced below with the patched fork at.yawk.lz4:lz4-java -->
                 <exclusion>
                     <groupId>org.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
@@ -55,11 +55,12 @@
             </exclusions>
         </dependency>
         <!-- Patched fork of lz4-java fixing CVE-2025-12183 and CVE-2025-66566.
-             The original org.lz4:lz4-java project is archived with no safe version available. -->
+             The original org.lz4:lz4-java project is archived with no safe version available.
+             1.11.1 additionally fixes CVE-2026-59949. -->
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.10.1</version>
+            <version>1.11.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem

The connector ships as a shaded fat jar, so bundled dependencies land in the released artifact. `at.yawk.lz4:lz4-java:1.10.1` — the maintained fork adopted here to replace the archived, vulnerable `org.lz4:lz4-java` — is itself affected by **CVE-2026-59949** (native XXHash implementations can crash the JVM). Fixed in **1.11.1**.

## Solution

Bump `at.yawk.lz4:lz4-java` `1.10.1` → `1.11.1` (drop-in patch, no API changes).

> Rebased onto `develop`. This PR previously also carried the `log4j-core 2.25.5` (CVE-2026-49844) bump, but that has since landed on `develop` via #480, so this PR is now just the lz4 bump.

## Testing

- `mvn package` builds on JDK 21; existing unit tests pass.
- The shaded fat jar embeds `at.yawk.lz4:lz4-java:1.11.1` (verified via its `META-INF/maven/.../pom.properties`).
- **Trivy** on the built fat jar: **CVE-2026-59949 cleared**.
