### PR TITLE
chore: update log4j to 2.25.5 for CVE-2026-49844

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Update log4j to 2.25.5 to resolve CVE-2026-49844